### PR TITLE
basic gutter with line numbers

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
 		6B0DCDD41E8196D0007C14A3 /* GutterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD31E8196D0007C14A3 /* GutterView.swift */; };
+		6B0DCDD61E832101007C14A3 /* EditViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD51E832101007C14A3 /* EditViewContainer.swift */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -52,6 +53,7 @@
 /* Begin PBXFileReference section */
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		6B0DCDD31E8196D0007C14A3 /* GutterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutterView.swift; sourceTree = "<group>"; };
+		6B0DCDD51E832101007C14A3 /* EditViewContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditViewContainer.swift; sourceTree = "<group>"; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "xi-syntect-plugin"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,6 +128,7 @@
 			children = (
 				F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */,
 				6B0DCDD31E8196D0007C14A3 /* GutterView.swift */,
+				6B0DCDD51E832101007C14A3 /* EditViewContainer.swift */,
 				AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */,
 				AED23F171C83CBEC002246CE /* EditView.swift */,
 				AEB66A781CAEFC8F002F686A /* ShadowView.swift */,
@@ -327,6 +330,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F53EA2AF1DCAAA170071ACFD /* EditViewController.swift in Sources */,
+				6B0DCDD61E832101007C14A3 /* EditViewContainer.swift in Sources */,
 				AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */,
 				AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */,
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
+		6B0DCDD41E8196D0007C14A3 /* GutterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD31E8196D0007C14A3 /* GutterView.swift */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -50,6 +51,7 @@
 
 /* Begin PBXFileReference section */
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
+		6B0DCDD31E8196D0007C14A3 /* GutterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutterView.swift; sourceTree = "<group>"; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "xi-syntect-plugin"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -123,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */,
+				6B0DCDD31E8196D0007C14A3 /* GutterView.swift */,
 				AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */,
 				AED23F171C83CBEC002246CE /* EditView.swift */,
 				AEB66A781CAEFC8F002F686A /* ShadowView.swift */,
@@ -330,6 +333,7 @@
 				50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */,
 				AED23F181C83CBED002246CE /* EditView.swift in Sources */,
 				AE499DD01C82BB2B002D68AF /* AppDelegate.swift in Sources */,
+				6B0DCDD41E8196D0007C14A3 /* GutterView.swift in Sources */,
 				F5BDBF371DCA9D2C0042430B /* Document.swift in Sources */,
 				AEB66A791CAEFC8F002F686A /* ShadowView.swift in Sources */,
 			);

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -14,6 +14,49 @@
 
 import Cocoa
 
+extension NSFont {
+    /// If the font is monospace, returns the width of a character, else returns 0.
+    func characterWidth() -> CGFloat {
+        if self.isFixedPitch {
+            let characters = [UniChar(0x20)]
+            var glyphs = [CGGlyph(0)]
+            if CTFontGetGlyphsForCharacters(self, characters, &glyphs, 1) {
+                let advance = CTFontGetAdvancesForGlyphs(self, .horizontal, glyphs, nil, 1)
+                return CGFloat(advance)
+            }
+        }
+        return 0
+    }
+}
+
+/// A store of properties used to determine the layout of text.
+struct TextDrawingMetrics {
+    var attributes: [String: AnyObject] = [:]
+    var ascent: CGFloat
+    var descent: CGFloat
+    var leading: CGFloat
+    var baseline: CGFloat
+    var linespace: CGFloat
+    var fontWidth: CGFloat
+    
+    init(font: NSFont) {
+        ascent = CTFontGetAscent(font)
+        descent = CTFontGetDescent(font)
+        leading = CTFontGetLeading(font)
+        linespace = ceil(ascent + descent + leading)
+        baseline = ceil(ascent)
+        fontWidth = font.characterWidth()
+        attributes[String(kCTFontAttributeName)] = font
+    }
+    
+    /// Passed an NSFontManager instance (as on a user-initiated font change) computes the next set of drawing metrics.
+    func newMetricsForFontChange(fontManager: NSFontManager) -> TextDrawingMetrics {
+        let oldFont = attributes[String(kCTFontAttributeName)] as! CTFont
+        let newFont = fontManager.convert(oldFont)
+        return TextDrawingMetrics(font: newFont)
+    }
+}
+
 func eventToJson(_ event: NSEvent) -> Any {
     let flags = event.modifierFlags.rawValue >> 16;
     return ["keycode": Int(event.keyCode),
@@ -23,19 +66,6 @@ func eventToJson(_ event: NSEvent) -> Any {
 
 func insertedStringToJson(_ stringToInsert: NSString) -> Any {
     return ["chars": stringToInsert]
-}
-
-// compute the width if monospaced, 0 otherwise
-func getFontWidth(_ font: CTFont) -> CGFloat {
-    if (font as NSFont).isFixedPitch {
-        let characters = [UniChar(0x20)]
-        var glyphs = [CGGlyph(0)]
-        if CTFontGetGlyphsForCharacters(font, characters, &glyphs, 1) {
-            let advance = CTFontGetAdvancesForGlyphs(font, .horizontal, glyphs, nil, 1)
-            return CGFloat(advance)
-        }
-    }
-    return 0
 }
 
 func colorFromArgb(_ argb: UInt32) -> NSColor {
@@ -69,14 +99,7 @@ class EditView: NSView, NSTextInputClient {
     var lines: LineCache
 
     @IBOutlet var heightConstraint: NSLayoutConstraint?
-
-    var attributes: [String: AnyObject]
-    var ascent: CGFloat
-    var descent: CGFloat
-    var leading: CGFloat
-    var baseline: CGFloat
-    var linespace: CGFloat
-    var fontWidth: CGFloat
+    var textMetrics: TextDrawingMetrics
 
     var textSelectionColor: NSColor {
         if self.isFrontmostView {
@@ -128,13 +151,7 @@ class EditView: NSView, NSTextInputClient {
     
     required init?(coder: NSCoder) {
         let font = CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil)
-        ascent = CTFontGetAscent(font)
-        descent = CTFontGetDescent(font)
-        leading = CTFontGetLeading(font)
-        linespace = ceil(ascent + descent + leading)
-        baseline = ceil(ascent)
-        attributes = [String(kCTFontAttributeName): font]
-        fontWidth = getFontWidth(font)
+        textMetrics = TextDrawingMetrics(font: font)
         _selectedRange = NSMakeRange(NSNotFound, 0)
         _markedRange = NSMakeRange(NSNotFound, 0)
         lines = LineCache()
@@ -144,16 +161,13 @@ class EditView: NSView, NSTextInputClient {
 
     // this gets called when the user changes the font with the font book, for example
     override func changeFont(_ sender: Any?) {
-        let oldFont = attributes[String(kCTFontAttributeName)] as! CTFont
-        let font = (sender as! NSFontManager).convert(oldFont)
-        ascent = CTFontGetAscent(font)
-        descent = CTFontGetDescent(font)
-        leading = CTFontGetLeading(font)
-        linespace = ceil(ascent + descent + leading)
-        baseline = ceil(ascent)
-        attributes[String(kCTFontAttributeName)] = font
-        fontWidth = getFontWidth(font)
+        if let manager = sender as? NSFontManager {
+        textMetrics = textMetrics.newMetricsForFontChange(fontManager: manager)
         needsDisplay = true
+        } else {
+            Swift.print("changeFont: called with nil")
+            return
+        }
     }
 
     let x0: CGFloat = 2;
@@ -175,8 +189,8 @@ class EditView: NSView, NSTextInputClient {
         */
 
         let context = NSGraphicsContext.current()!.cgContext
-        let first = Int(floor(dirtyRect.origin.y / linespace))
-        let last = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height) / linespace))
+        let first = Int(floor(dirtyRect.origin.y / textMetrics.linespace))
+        let last = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height) / textMetrics.linespace))
 
         let missing = lines.computeMissing(first, last)
         for (f, l) in missing {
@@ -188,14 +202,14 @@ class EditView: NSView, NSTextInputClient {
         for lineIx in first..<last {
             guard let line = getLine(lineIx), line.containsSelection == true else { continue }
             let selections = line.styles.filter { $0.style == 0 }
-            let attrString = NSMutableAttributedString(string: line.text, attributes: self.attributes)
+            let attrString = NSMutableAttributedString(string: line.text, attributes: textMetrics.attributes)
             let ctline = CTLineCreateWithAttributedString(attrString)
-            let y = linespace * CGFloat(lineIx + 1)
+            let y = textMetrics.linespace * CGFloat(lineIx + 1)
             context.setFillColor(textSelectionColor.cgColor)
             for selection in selections {
                 let selStart = CTLineGetOffsetForStringIndex(ctline, selection.range.location, nil)
                 let selEnd = CTLineGetOffsetForStringIndex(ctline, selection.range.location + selection.range.length, nil)
-                context.fill(CGRect.init(x: x0 + selStart, y: y - ascent, width: selEnd - selStart, height: linespace))
+                context.fill(CGRect.init(x: x0 + selStart, y: y - textMetrics.ascent, width: selEnd - selStart, height: textMetrics.linespace))
             }
             
         }
@@ -204,7 +218,7 @@ class EditView: NSView, NSTextInputClient {
             // TODO: could block for ~1ms waiting for missing lines to arrive
             guard let line = getLine(lineIx) else { continue }
             let s = line.text
-            var attrString = NSMutableAttributedString(string: s, attributes: self.attributes)
+            var attrString = NSMutableAttributedString(string: s, attributes: textMetrics.attributes)
             /*
             let randcolor = NSColor(colorLiteralRed: Float(drand48()), green: Float(drand48()), blue: Float(drand48()), alpha: 1.0)
             attrString.addAttribute(NSForegroundColorAttributeName, value: randcolor, range: NSMakeRange(0, s.utf16.count))
@@ -234,7 +248,7 @@ class EditView: NSView, NSTextInputClient {
             // probably want to move to using CTLineDraw instead of drawing the attributed string,
             // but that means drawing the selection highlight ourselves (which has other benefits).
             //attrString.drawAtPoint(NSPoint(x: x0, y: y - 13))
-            let y = linespace * CGFloat(lineIx + 1);
+            let y = textMetrics.linespace * CGFloat(lineIx + 1);
             attrString.draw(with: NSRect(x: x0, y: y, width: dirtyRect.origin.x + dirtyRect.width - x0, height: 14), options: [])
             if showBlinkingCursor {
                 for cursor in line.cursor {
@@ -250,8 +264,8 @@ class EditView: NSView, NSTextInputClient {
                         pos = CTLineGetOffsetForStringIndex(ctline, CFIndex(utf16_ix), nil)
                     }
                     context.setStrokeColor(cursorColor)
-                    context.move(to: CGPoint(x: x0 + pos, y: y + descent))
-                    context.addLine(to: CGPoint(x: x0 + pos, y: y - ascent))
+                    context.move(to: CGPoint(x: x0 + pos, y: y + textMetrics.descent))
+                    context.addLine(to: CGPoint(x: x0 + pos, y: y - textMetrics.ascent))
                     context.strokePath()
                 }
             }
@@ -272,16 +286,16 @@ class EditView: NSView, NSTextInputClient {
     /// apply the given updates to the view.
     public func update(update: [String: AnyObject]) {
         lines.applyUpdate(update: update)
-        self.heightConstraint?.constant = CGFloat(lines.height) * self.linespace + 2 * self.descent
+        self.heightConstraint?.constant = CGFloat(lines.height) * textMetrics.linespace + 2 * textMetrics.descent
         self.showBlinkingCursor = self.isFrontmostView
         self.needsDisplay = true
     }
 
     /// scrolls the editview to display the given line and column
     public func scrollTo(_ line: Int, _ col: Int) {
-        let x = CGFloat(col) * fontWidth  // TODO: deal with non-ASCII, non-monospaced case
-        let y = CGFloat(line) * linespace + baseline
-        let scrollRect = NSRect(x: x, y: y - baseline, width: 4, height: linespace + descent)
+        let x = CGFloat(col) * textMetrics.fontWidth  // TODO: deal with non-ASCII, non-monospaced case
+        let y = CGFloat(line) * textMetrics.linespace + textMetrics.baseline
+        let scrollRect = NSRect(x: x, y: y - textMetrics.baseline, width: 4, height: textMetrics.linespace + textMetrics.descent)
         self.scrollToVisible(scrollRect)
     }
 
@@ -390,12 +404,12 @@ class EditView: NSView, NSTextInputClient {
             let (lineIx, pos) = self.cursorPos,
             let line = getLine(lineIx) {
             let str = line.text
-            let ctLine = CTLineCreateWithAttributedString(NSMutableAttributedString(string: str, attributes: self.attributes))
+            let ctLine = CTLineCreateWithAttributedString(NSMutableAttributedString(string: str, attributes: textMetrics.attributes))
             let rangeWidth = CTLineGetOffsetForStringIndex(ctLine, pos, nil) - CTLineGetOffsetForStringIndex(ctLine, pos - aRange.length, nil)
             return NSRect(x: viewWinFrame.origin.x + CTLineGetOffsetForStringIndex(ctLine, pos, nil),
-                          y: viewWinFrame.origin.y + viewWinFrame.size.height - linespace * CGFloat(lineIx + 1) - 5,
+                          y: viewWinFrame.origin.y + viewWinFrame.size.height - textMetrics.linespace * CGFloat(lineIx + 1) - 5,
                           width: rangeWidth,
-                          height: linespace)
+                          height: textMetrics.linespace)
         } else {
             return NSRect(x: 0, y: 0, width: 0, height: 0)
         }
@@ -460,11 +474,11 @@ class EditView: NSView, NSTextInputClient {
 
     // TODO: more functions should call this, just dividing by linespace doesn't account for descent
     func yToLine(_ y: CGFloat) -> Int {
-        return Int(floor(max(y - descent, 0) / linespace))
+        return Int(floor(max(y - textMetrics.descent, 0) / textMetrics.linespace))
     }
 
     func lineIxToBaseline(_ lineIx: Int) -> CGFloat {
-        return CGFloat(lineIx + 1) * linespace
+        return CGFloat(lineIx + 1) * textMetrics.linespace
     }
 
     func pointToLineCol(_ loc: NSPoint) -> (Int, Int) {
@@ -472,7 +486,7 @@ class EditView: NSView, NSTextInputClient {
         var col = 0
         if let line = getLine(lineIx) {
             let s = line.text
-            let attrString = NSAttributedString(string: s, attributes: self.attributes)
+            let attrString = NSAttributedString(string: s, attributes: textMetrics.attributes)
             let ctline = CTLineCreateWithAttributedString(attrString)
             let relPos = NSPoint(x: loc.x - x0, y: lineIxToBaseline(lineIx) - loc.y)
             let utf16_ix = CTLineGetStringIndexForPosition(ctline, relPos)

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -260,17 +260,6 @@ class EditView: NSView, NSTextInputClient {
         return true;
     }
     
-    //MARK: - Public API
-
-    /// scrolls the editview to display the given line and column
-    public func scrollTo(_ line: Int, _ col: Int) {
-        let x = CGFloat(col) * dataSource.textMetrics.fontWidth  // TODO: deal with non-ASCII, non-monospaced case
-        let y = CGFloat(line) * dataSource.textMetrics.linespace + dataSource.textMetrics.baseline
-        let scrollRect = NSRect(x: x, y: y - dataSource.textMetrics.baseline, width: 4, height: dataSource.textMetrics.linespace + dataSource.textMetrics.descent)
-        self.scrollToVisible(scrollRect)
-    }
-
-    
     // MARK: - NSTextInputClient protocol
     func insertText(_ aString: Any, replacementRange: NSRange) {
         self.removeMarkedText()

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -57,12 +57,9 @@ struct TextDrawingMetrics {
     }
 }
 
-func eventToJson(_ event: NSEvent) -> Any {
-    let flags = event.modifierFlags.rawValue >> 16;
-    return ["keycode": Int(event.keyCode),
-        "chars": event.characters!,
-        "flags": flags]
-}
+/// A line-column index into a displayed text buffer.
+typealias BufferPosition = (line: Int, column: Int)
+
 
 func insertedStringToJson(_ stringToInsert: NSString) -> Any {
     return ["chars": stringToInsert]
@@ -412,42 +409,6 @@ class EditView: NSView, NSTextInputClient {
             }
         }
     }
-
-    override func mouseDown(with theEvent: NSEvent) {
-        removeMarkedText()
-        self.inputContext?.discardMarkedText()
-        let (line, col) = pointToLineCol(convert(theEvent.locationInWindow, from: nil))
-        lastDragLineCol = (line, col)
-        let flags = theEvent.modifierFlags.rawValue >> 16
-        let clickCount = theEvent.clickCount
-        document?.sendRpcAsync("click", params: [line, col, flags, clickCount])
-        timer = Timer.scheduledTimer(timeInterval: TimeInterval(1.0/60), target: self, selector: #selector(_autoscrollTimerCallback), userInfo: nil, repeats: true)
-        timerEvent = theEvent
-    }
-
-    override func mouseDragged(with theEvent: NSEvent) {
-        autoscroll(with: theEvent)
-        let (line, col) = pointToLineCol(convert(theEvent.locationInWindow, from: nil))
-        if let last = lastDragLineCol, last != (line, col) {
-            lastDragLineCol = (line, col)
-            let flags = theEvent.modifierFlags.rawValue >> 16
-            document?.sendRpcAsync("drag", params: [line, col, flags])
-        }
-        timerEvent = theEvent
-    }
-
-    override func mouseUp(with theEvent: NSEvent) {
-        timer?.invalidate()
-        timer = nil
-        timerEvent = nil
-    }
-    
-    // MARK: - Helpers etc
-    func _autoscrollTimerCallback() {
-        if let event = timerEvent {
-            mouseDragged(with: event)
-        }
-    }
     
     /// timer callback to toggle the blink state
     func _blinkInsertionPoint() {
@@ -464,20 +425,23 @@ class EditView: NSView, NSTextInputClient {
         return CGFloat(lineIx + 1) * dataSource.textMetrics.linespace
     }
 
-    func pointToLineCol(_ loc: NSPoint) -> (Int, Int) {
-        let lineIx = yToLine(loc.y)
-        var col = 0
+    /// given a point in the containing window's coordinate space, converts it into a line / column position in the current view.
+    /// Note: - The returned position is not guaruanteed to be an existing line. For instance, if a buffer does not fill the current window, a point below the last line will return a buffer position with a line number exceeding the number of lines in the file. In this case position.column will always be zero.
+    func bufferPositionFromPoint(_ point: NSPoint) -> BufferPosition {
+        let point = self.convert(point, from: nil)
+        let lineIx = yToLine(point.y)
         if let line = getLine(lineIx) {
             let s = line.text
             let attrString = NSAttributedString(string: s, attributes: dataSource.textMetrics.attributes)
             let ctline = CTLineCreateWithAttributedString(attrString)
-            let relPos = NSPoint(x: loc.x - x0, y: lineIxToBaseline(lineIx) - loc.y)
+            let relPos = NSPoint(x: point.x - x0, y: lineIxToBaseline(lineIx) - point.y)
             let utf16_ix = CTLineGetStringIndexForPosition(ctline, relPos)
             if utf16_ix != kCFNotFound {
-                col = utf16_offset_to_utf8(s, utf16_ix)
+                let col = utf16_offset_to_utf8(s, utf16_ix)
+                return BufferPosition(line: lineIx, column: col)
             }
         }
-        return (lineIx, col)
+        return BufferPosition(line: lineIx, column: 0)
     }
 
     private func utf8_offset_to_utf16(_ s: String, _ ix: Int) -> Int {

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -94,12 +94,9 @@ func camelCaseToUnderscored(_ name: NSString) -> NSString {
 
 class EditView: NSView, NSTextInputClient {
     var document: Document!
-
-    var styleMap: StyleMap?
-    var lines: LineCache
+    var dataSource: EditViewDataSource!
 
     @IBOutlet var heightConstraint: NSLayoutConstraint?
-    var textMetrics: TextDrawingMetrics
 
     var textSelectionColor: NSColor {
         if self.isFrontmostView {
@@ -150,24 +147,10 @@ class EditView: NSView, NSTextInputClient {
     }
     
     required init?(coder: NSCoder) {
-        let font = CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil)
-        textMetrics = TextDrawingMetrics(font: font)
+        
         _selectedRange = NSMakeRange(NSNotFound, 0)
         _markedRange = NSMakeRange(NSNotFound, 0)
-        lines = LineCache()
-        styleMap = (NSApplication.shared().delegate as? AppDelegate)?.styleMap
         super.init(coder: coder)
-    }
-
-    // this gets called when the user changes the font with the font book, for example
-    override func changeFont(_ sender: Any?) {
-        if let manager = sender as? NSFontManager {
-        textMetrics = textMetrics.newMetricsForFontChange(fontManager: manager)
-        needsDisplay = true
-        } else {
-            Swift.print("changeFont: called with nil")
-            return
-        }
     }
 
     let x0: CGFloat = 2;
@@ -189,10 +172,10 @@ class EditView: NSView, NSTextInputClient {
         */
 
         let context = NSGraphicsContext.current()!.cgContext
-        let first = Int(floor(dirtyRect.origin.y / textMetrics.linespace))
-        let last = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height) / textMetrics.linespace))
+        let first = Int(floor(dirtyRect.origin.y / dataSource.textMetrics.linespace))
+        let last = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height) / dataSource.textMetrics.linespace))
 
-        let missing = lines.computeMissing(first, last)
+        let missing = dataSource.lines.computeMissing(first, last)
         for (f, l) in missing {
             Swift.print("requesting missing: \(f)..\(l)")
             document?.sendRpcAsync("request_lines", params: [f, l])
@@ -202,14 +185,14 @@ class EditView: NSView, NSTextInputClient {
         for lineIx in first..<last {
             guard let line = getLine(lineIx), line.containsSelection == true else { continue }
             let selections = line.styles.filter { $0.style == 0 }
-            let attrString = NSMutableAttributedString(string: line.text, attributes: textMetrics.attributes)
+            let attrString = NSMutableAttributedString(string: line.text, attributes: dataSource.textMetrics.attributes)
             let ctline = CTLineCreateWithAttributedString(attrString)
-            let y = textMetrics.linespace * CGFloat(lineIx + 1)
+            let y = dataSource.textMetrics.linespace * CGFloat(lineIx + 1)
             context.setFillColor(textSelectionColor.cgColor)
             for selection in selections {
                 let selStart = CTLineGetOffsetForStringIndex(ctline, selection.range.location, nil)
                 let selEnd = CTLineGetOffsetForStringIndex(ctline, selection.range.location + selection.range.length, nil)
-                context.fill(CGRect.init(x: x0 + selStart, y: y - textMetrics.ascent, width: selEnd - selStart, height: textMetrics.linespace))
+                context.fill(CGRect.init(x: x0 + selStart, y: y - dataSource.textMetrics.ascent, width: selEnd - selStart, height: dataSource.textMetrics.linespace))
             }
             
         }
@@ -218,12 +201,12 @@ class EditView: NSView, NSTextInputClient {
             // TODO: could block for ~1ms waiting for missing lines to arrive
             guard let line = getLine(lineIx) else { continue }
             let s = line.text
-            var attrString = NSMutableAttributedString(string: s, attributes: textMetrics.attributes)
+            var attrString = NSMutableAttributedString(string: s, attributes: dataSource.textMetrics.attributes)
             /*
             let randcolor = NSColor(colorLiteralRed: Float(drand48()), green: Float(drand48()), blue: Float(drand48()), alpha: 1.0)
             attrString.addAttribute(NSForegroundColorAttributeName, value: randcolor, range: NSMakeRange(0, s.utf16.count))
             */
-            styleMap?.applyStyles(text: s, string: &attrString, styles: line.styles)
+            dataSource.styleMap.applyStyles(text: s, string: &attrString, styles: line.styles)
             for c in line.cursor {
                 let cix = utf8_offset_to_utf16(s, c)
                 if (markedRange().location != NSNotFound) {
@@ -248,7 +231,7 @@ class EditView: NSView, NSTextInputClient {
             // probably want to move to using CTLineDraw instead of drawing the attributed string,
             // but that means drawing the selection highlight ourselves (which has other benefits).
             //attrString.drawAtPoint(NSPoint(x: x0, y: y - 13))
-            let y = textMetrics.linespace * CGFloat(lineIx + 1);
+            let y = dataSource.textMetrics.linespace * CGFloat(lineIx + 1);
             attrString.draw(with: NSRect(x: x0, y: y, width: dirtyRect.origin.x + dirtyRect.width - x0, height: 14), options: [])
             if showBlinkingCursor {
                 for cursor in line.cursor {
@@ -264,8 +247,8 @@ class EditView: NSView, NSTextInputClient {
                         pos = CTLineGetOffsetForStringIndex(ctline, CFIndex(utf16_ix), nil)
                     }
                     context.setStrokeColor(cursorColor)
-                    context.move(to: CGPoint(x: x0 + pos, y: y + textMetrics.descent))
-                    context.addLine(to: CGPoint(x: x0 + pos, y: y - textMetrics.ascent))
+                    context.move(to: CGPoint(x: x0 + pos, y: y + dataSource.textMetrics.descent))
+                    context.addLine(to: CGPoint(x: x0 + pos, y: y - dataSource.textMetrics.ascent))
                     context.strokePath()
                 }
             }
@@ -285,17 +268,17 @@ class EditView: NSView, NSTextInputClient {
     
     /// apply the given updates to the view.
     public func update(update: [String: AnyObject]) {
-        lines.applyUpdate(update: update)
-        self.heightConstraint?.constant = CGFloat(lines.height) * textMetrics.linespace + 2 * textMetrics.descent
+        dataSource.lines.applyUpdate(update: update)
+        self.heightConstraint?.constant = CGFloat(dataSource.lines.height) * dataSource.textMetrics.linespace + 2 * dataSource.textMetrics.descent
         self.showBlinkingCursor = self.isFrontmostView
         self.needsDisplay = true
     }
 
     /// scrolls the editview to display the given line and column
     public func scrollTo(_ line: Int, _ col: Int) {
-        let x = CGFloat(col) * textMetrics.fontWidth  // TODO: deal with non-ASCII, non-monospaced case
-        let y = CGFloat(line) * textMetrics.linespace + textMetrics.baseline
-        let scrollRect = NSRect(x: x, y: y - textMetrics.baseline, width: 4, height: textMetrics.linespace + textMetrics.descent)
+        let x = CGFloat(col) * dataSource.textMetrics.fontWidth  // TODO: deal with non-ASCII, non-monospaced case
+        let y = CGFloat(line) * dataSource.textMetrics.linespace + dataSource.textMetrics.baseline
+        let scrollRect = NSRect(x: x, y: y - dataSource.textMetrics.baseline, width: 4, height: dataSource.textMetrics.linespace + dataSource.textMetrics.descent)
         self.scrollToVisible(scrollRect)
     }
 
@@ -404,12 +387,12 @@ class EditView: NSView, NSTextInputClient {
             let (lineIx, pos) = self.cursorPos,
             let line = getLine(lineIx) {
             let str = line.text
-            let ctLine = CTLineCreateWithAttributedString(NSMutableAttributedString(string: str, attributes: textMetrics.attributes))
+            let ctLine = CTLineCreateWithAttributedString(NSMutableAttributedString(string: str, attributes: dataSource.textMetrics.attributes))
             let rangeWidth = CTLineGetOffsetForStringIndex(ctLine, pos, nil) - CTLineGetOffsetForStringIndex(ctLine, pos - aRange.length, nil)
             return NSRect(x: viewWinFrame.origin.x + CTLineGetOffsetForStringIndex(ctLine, pos, nil),
-                          y: viewWinFrame.origin.y + viewWinFrame.size.height - textMetrics.linespace * CGFloat(lineIx + 1) - 5,
+                          y: viewWinFrame.origin.y + viewWinFrame.size.height - dataSource.textMetrics.linespace * CGFloat(lineIx + 1) - 5,
                           width: rangeWidth,
-                          height: textMetrics.linespace)
+                          height: dataSource.textMetrics.linespace)
         } else {
             return NSRect(x: 0, y: 0, width: 0, height: 0)
         }
@@ -474,11 +457,11 @@ class EditView: NSView, NSTextInputClient {
 
     // TODO: more functions should call this, just dividing by linespace doesn't account for descent
     func yToLine(_ y: CGFloat) -> Int {
-        return Int(floor(max(y - textMetrics.descent, 0) / textMetrics.linespace))
+        return Int(floor(max(y - dataSource.textMetrics.descent, 0) / dataSource.textMetrics.linespace))
     }
 
     func lineIxToBaseline(_ lineIx: Int) -> CGFloat {
-        return CGFloat(lineIx + 1) * textMetrics.linespace
+        return CGFloat(lineIx + 1) * dataSource.textMetrics.linespace
     }
 
     func pointToLineCol(_ loc: NSPoint) -> (Int, Int) {
@@ -486,7 +469,7 @@ class EditView: NSView, NSTextInputClient {
         var col = 0
         if let line = getLine(lineIx) {
             let s = line.text
-            let attrString = NSAttributedString(string: s, attributes: textMetrics.attributes)
+            let attrString = NSAttributedString(string: s, attributes: dataSource.textMetrics.attributes)
             let ctline = CTLineCreateWithAttributedString(attrString)
             let relPos = NSPoint(x: loc.x - x0, y: lineIxToBaseline(lineIx) - loc.y)
             let utf16_ix = CTLineGetStringIndexForPosition(ctline, relPos)
@@ -507,6 +490,6 @@ class EditView: NSView, NSTextInputClient {
     }
 
     func getLine(_ lineNum: Int) -> Line? {
-        return lines.get(lineNum)
+        return dataSource.lines.get(lineNum)
     }
 }

--- a/XiEditor/EditViewContainer.swift
+++ b/XiEditor/EditViewContainer.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2017 Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/EditViewContainer.swift
+++ b/XiEditor/EditViewContainer.swift
@@ -1,0 +1,22 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Cocoa
+
+class EditViewContainer: NSView {
+
+    override var isFlipped: Bool {
+        return true
+    }
+}

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -14,7 +14,15 @@
 
 import Cocoa
 
-class EditViewController: NSViewController {
+/// The EditViewDataSource protocol describes the properties that an editView uses to determine how to render its contents.
+protocol EditViewDataSource {
+    var lines: LineCache { get }
+    var styleMap: StyleMap { get }
+    var textMetrics: TextDrawingMetrics { get }
+}
+
+
+class EditViewController: NSViewController, EditViewDataSource {
 
     @IBOutlet var editView: EditView!
     @IBOutlet var shadowView: ShadowView!
@@ -26,13 +34,22 @@ class EditViewController: NSViewController {
             editView.document = document
         }
     }
+    
+    var lines: LineCache = LineCache()
+    var styleMap: StyleMap {
+        return (NSApplication.shared().delegate as! AppDelegate).styleMap
+    }
 
+    //TODO: preferred font should be a user preference
+    var textMetrics = TextDrawingMetrics(font: CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil))
+    
     // visible scroll region, exclusive of lastLine
     var firstLine: Int = 0
     var lastLine: Int = 0
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        editView.dataSource = self
         self.shadowView.mouseUpHandler = editView.mouseUp(with:)
         self.shadowView.mouseDraggedHandler = editView.mouseDragged(with:)
         scrollView.contentView.documentCursor = NSCursor.iBeam();
@@ -40,6 +57,18 @@ class EditViewController: NSViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.boundsDidChangeNotification(_:)), name: NSNotification.Name.NSViewBoundsDidChange, object: scrollView.contentView)
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSNotification.Name.NSViewFrameDidChange, object: scrollView)
     }
+
+    // this gets called when the user changes the font with the font book, for example
+    override func changeFont(_ sender: Any?) {
+        if let manager = sender as? NSFontManager {
+            textMetrics = textMetrics.newMetricsForFontChange(fontManager: manager)
+            self.editView.needsDisplay = true
+        } else {
+            Swift.print("changeFont: called with nil")
+            return
+        }
+    }
+
     
     func boundsDidChangeNotification(_ notification: Notification) {
         updateEditViewScroll()
@@ -49,10 +78,9 @@ class EditViewController: NSViewController {
         updateEditViewScroll()
     }
 
-    
     fileprivate func updateEditViewScroll() {
-        let first = Int(floor(scrollView.contentView.bounds.origin.y / editView.textMetrics.linespace))
-        let height = Int(ceil((scrollView.contentView.bounds.size.height) / editView.textMetrics.linespace))
+        let first = Int(floor(scrollView.contentView.bounds.origin.y / textMetrics.linespace))
+        let height = Int(ceil((scrollView.contentView.bounds.size.height) / textMetrics.linespace))
         let last = first + height
         if first != firstLine || last != lastLine && document != nil {
             firstLine = first
@@ -95,7 +123,7 @@ class EditViewController: NSViewController {
 
     // we override this to see if our view is empty, and should be reused for this open call
      func openDocument(_ sender: Any?) {
-        if editView?.lines.isEmpty ?? false {
+        if self.lines.isEmpty {
             Document._documentForNextOpenCall = self.document
         }
         Document.preferredTabbingIdentifier = nil

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -47,6 +47,11 @@ class EditViewController: NSViewController, EditViewDataSource {
     var firstLine: Int = 0
     var lastLine: Int = 0
 
+    private var lastDragPosition: BufferPosition?
+    /// handles autoscrolling when a drag gesture exists the window
+    private var dragTimer: Timer?
+    private var dragEvent: NSEvent?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         editView.dataSource = self
@@ -102,6 +107,41 @@ class EditViewController: NSViewController, EditViewDataSource {
     // MARK: - System Events
     override func keyDown(with theEvent: NSEvent) {
         self.editView.inputContext?.handleEvent(theEvent);
+    }
+    
+    override func mouseDown(with theEvent: NSEvent) {
+        editView.removeMarkedText()
+        editView.inputContext?.discardMarkedText()
+        let position  = editView.bufferPositionFromPoint(theEvent.locationInWindow)
+        lastDragPosition = position
+        let flags = theEvent.modifierFlags.rawValue >> 16
+        let clickCount = theEvent.clickCount
+        document.sendRpcAsync("click", params: [position.line, position.column, flags, clickCount])
+        dragTimer = Timer.scheduledTimer(timeInterval: TimeInterval(1.0/60), target: self, selector: #selector(_autoscrollTimerCallback), userInfo: nil, repeats: true)
+        dragEvent = theEvent
+    }
+    
+    override func mouseDragged(with theEvent: NSEvent) {
+        editView.autoscroll(with: theEvent)
+        let dragPosition = editView.bufferPositionFromPoint(theEvent.locationInWindow)
+        if let last = lastDragPosition, last != dragPosition {
+            lastDragPosition = dragPosition
+            let flags = theEvent.modifierFlags.rawValue >> 16
+            document?.sendRpcAsync("drag", params: [last.line, last.column, flags])
+        }
+        dragEvent = theEvent
+    }
+    
+    override func mouseUp(with theEvent: NSEvent) {
+        dragTimer?.invalidate()
+        dragTimer = nil
+        dragEvent = nil
+    }
+    
+    func _autoscrollTimerCallback() {
+        if let event = dragEvent {
+            mouseDragged(with: event)
+        }
     }
     
     // NSResponder (used mostly for paste)

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -25,11 +25,14 @@ protocol EditViewDataSource {
 
 class EditViewController: NSViewController, EditViewDataSource {
 
-    @IBOutlet var editView: EditView!
+    
     @IBOutlet var shadowView: ShadowView!
     @IBOutlet var scrollView: NSScrollView!
     @IBOutlet var documentView: NSClipView!
+    @IBOutlet weak var editViewContainer: NSView!
+    @IBOutlet var editView: EditView!
     @IBOutlet weak var gutterView: GutterView!
+    
     @IBOutlet weak var gutterViewWidth: NSLayoutConstraint!
     @IBOutlet weak var editViewHeight: NSLayoutConstraint!
     
@@ -126,7 +129,10 @@ class EditViewController: NSViewController, EditViewDataSource {
     }
 
     func scrollTo(_ line: Int, _ col: Int) {
-        editView.scrollTo(line, col)
+        let x = CGFloat(col) * textMetrics.fontWidth  // TODO: deal with non-ASCII, non-monospaced case
+        let y = CGFloat(line) * textMetrics.linespace + textMetrics.baseline
+        let scrollRect = NSRect(x: x, y: y - textMetrics.baseline, width: 4, height: textMetrics.linespace + textMetrics.descent)
+        editViewContainer.scrollToVisible(scrollRect)
     }
     
     // MARK: - System Events

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -51,8 +51,8 @@ class EditViewController: NSViewController {
 
     
     fileprivate func updateEditViewScroll() {
-        let first = Int(floor(scrollView.contentView.bounds.origin.y / editView.linespace))
-        let height = Int(ceil((scrollView.contentView.bounds.size.height) / editView.linespace))
+        let first = Int(floor(scrollView.contentView.bounds.origin.y / editView.textMetrics.linespace))
+        let height = Int(ceil((scrollView.contentView.bounds.size.height) / editView.textMetrics.linespace))
         let last = first + height
         if first != firstLine || last != lastLine && document != nil {
             firstLine = first

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -28,8 +28,7 @@ class EditViewController: NSViewController, EditViewDataSource {
     
     @IBOutlet var shadowView: ShadowView!
     @IBOutlet var scrollView: NSScrollView!
-    @IBOutlet var documentView: NSClipView!
-    @IBOutlet weak var editViewContainer: NSView!
+    @IBOutlet weak var editViewContainer: EditViewContainer!
     @IBOutlet var editView: EditView!
     @IBOutlet weak var gutterView: GutterView!
     
@@ -78,8 +77,6 @@ class EditViewController: NSViewController, EditViewDataSource {
         super.viewDidLoad()
         editView.dataSource = self
         gutterView.dataSource = self
-        self.shadowView.mouseUpHandler = editView.mouseUp(with:)
-        self.shadowView.mouseDraggedHandler = editView.mouseDragged(with:)
         scrollView.contentView.documentCursor = NSCursor.iBeam();
         
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.boundsDidChangeNotification(_:)), name: NSNotification.Name.NSViewBoundsDidChange, object: scrollView.contentView)
@@ -116,6 +113,8 @@ class EditViewController: NSViewController, EditViewDataSource {
             document?.sendRpcAsync("scroll", params: [firstLine, lastLine])
         }
         shadowView?.updateScroll(scrollView.contentView.bounds, scrollView.documentView!.bounds)
+        // if the window is resized, update the editViewHeight so we don't show scrollers unnecessarily
+        self.editViewHeight.constant = max(CGFloat(lines.height) * textMetrics.linespace + 2 * textMetrics.descent, scrollView.bounds.height)
     }
     
     // MARK: - Core Commands

--- a/XiEditor/GutterView.swift
+++ b/XiEditor/GutterView.swift
@@ -47,7 +47,7 @@ class GutterView: NSView {
             let y = dataSource.textMetrics.linespace * CGFloat(lineNb + 1)
             let hasCursor = dataSource.lines.get(lineNb)?.containsCursor ?? false
             let fontAttributes = hasCursor ? cursorAttributes : defaultAttributes
-            let attrString = NSMutableAttributedString(string: "\(lineNb)", attributes: fontAttributes)
+            let attrString = NSMutableAttributedString(string: "\(lineNb+1)", attributes: fontAttributes)
             let expectedSize = attrString.size()
             attrString.draw(with: NSRect(x: dataSource.gutterWidth - expectedSize.width - xPadding, y: y, width: expectedSize.width, height: expectedSize.height), options: NSStringDrawingOptions(rawValue: 0))
         }

--- a/XiEditor/GutterView.swift
+++ b/XiEditor/GutterView.swift
@@ -1,0 +1,48 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Cocoa
+
+class GutterView: NSView {
+    var dataSource: EditViewDataSource!
+    let xPadding: CGFloat = 8
+
+    override var isFlipped: Bool {
+        return true
+    }
+    
+    override func draw(_ dirtyRect: NSRect) {
+        let context = NSGraphicsContext.current()!.cgContext
+        NSColor(deviceWhite: 0.9, alpha: 1.0).setFill()
+        NSRectFill(dirtyRect)
+        context.setShouldSmoothFonts(true)
+        
+        var fontAttributes = dataSource.textMetrics.attributes
+        fontAttributes[NSForegroundColorAttributeName] = NSColor(deviceWhite: 0.5, alpha: 1.0)
+        let first = Int(floor(dirtyRect.origin.y / dataSource.textMetrics.linespace))
+        let last = min(Int(ceil((dirtyRect.origin.y + dirtyRect.size.height) / dataSource.textMetrics.linespace)), dataSource.lines.height)
+        guard first < last else {
+            Swift.print("gutterview first > last")
+            return
+        }
+
+        for lineNb in first..<last {
+            let y = dataSource.textMetrics.linespace * CGFloat(lineNb + 1)
+            let attrString = NSMutableAttributedString(string: "\(lineNb)", attributes: fontAttributes)
+            let expectedSize = attrString.size()
+            attrString.draw(with: NSRect(x: dataSource.gutterWidth - expectedSize.width - xPadding, y: y, width: expectedSize.width, height: expectedSize.height), options: NSStringDrawingOptions(rawValue: 0))
+        }
+        super.draw(dirtyRect)
+    }
+}

--- a/XiEditor/GutterView.swift
+++ b/XiEditor/GutterView.swift
@@ -17,21 +17,27 @@ import Cocoa
 class GutterView: NSView {
     var dataSource: EditViewDataSource!
     let xPadding: CGFloat = 8
-
+    
+    private let gutterBackground = NSColor(deviceWhite: 0.9, alpha: 1.0)
+    private let lineNumberDefaultTextColor = NSColor(deviceWhite: 0.5, alpha: 1.0)
+    private let lineNumberCursorTextColor = NSColor.black
+    
     override var isFlipped: Bool {
         return true
     }
     
     override func draw(_ dirtyRect: NSRect) {
-        let context = NSGraphicsContext.current()!.cgContext
-        NSColor(deviceWhite: 0.9, alpha: 1.0).setFill()
+        gutterBackground.setFill()
         NSRectFill(dirtyRect)
-        context.setShouldSmoothFonts(true)
         
-        var fontAttributes = dataSource.textMetrics.attributes
-        fontAttributes[NSForegroundColorAttributeName] = NSColor(deviceWhite: 0.5, alpha: 1.0)
+        var defaultAttributes = dataSource.textMetrics.attributes
+        var cursorAttributes = dataSource.textMetrics.attributes
+        defaultAttributes[NSForegroundColorAttributeName] = lineNumberDefaultTextColor
+        cursorAttributes[NSForegroundColorAttributeName] = lineNumberCursorTextColor
+
         let first = Int(floor(dirtyRect.origin.y / dataSource.textMetrics.linespace))
         let last = min(Int(ceil((dirtyRect.origin.y + dirtyRect.size.height) / dataSource.textMetrics.linespace)), dataSource.lines.height)
+
         guard first < last else {
             Swift.print("gutterview first > last")
             return
@@ -39,6 +45,8 @@ class GutterView: NSView {
 
         for lineNb in first..<last {
             let y = dataSource.textMetrics.linespace * CGFloat(lineNb + 1)
+            let hasCursor = dataSource.lines.get(lineNb)?.containsCursor ?? false
+            let fontAttributes = hasCursor ? cursorAttributes : defaultAttributes
             let attrString = NSMutableAttributedString(string: "\(lineNb)", attributes: fontAttributes)
             let expectedSize = attrString.size()
             attrString.draw(with: NSRect(x: dataSource.gutterWidth - expectedSize.width - xPadding, y: y, width: expectedSize.width, height: expectedSize.height), options: NSStringDrawingOptions(rawValue: 0))

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -167,6 +167,11 @@ class LineCache {
     func computeMissing(_ first: Int, _ last: Int) -> [(Int, Int)] {
         var result: [(Int, Int)] = []
         let last = min(last, height)  // lines past the end aren't considered missing
+        guard first < last else {
+            Swift.print("compute missing called with first > last")
+            return result
+        }
+        
         for ix in first..<last {
             // could optimize a bit here, but unlikely to be important
             if ix < nInvalidBefore || ix >= nInvalidBefore + lines.count || lines[ix - nInvalidBefore] == nil {

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -25,18 +25,16 @@ struct Line {
     var containsSelection: Bool {
             return styles.contains { $0.style == 0 }
         }
+    
+    /// A Boolean indicating whether this line contains a cursor.
+    var containsCursor: Bool {
+        return cursor.count > 0
+    }
 
     init(fromJson json: [String: AnyObject]) {
-        if let text = json["text"] as? String {
-            self.text = text
-        } else {
-            self.text = ""  // this should probably be an exception
-        }
-        if let cursor = json["cursor"] as? [Int] {
-            self.cursor = cursor
-        } else {
-            self.cursor = []
-        }
+        // this could be a more clear exception
+        text = json["text"] as! String
+        cursor = json["cursor"] as? [Int] ?? []
         if let styles = json["styles"] as? [Int] {
             self.styles = StyleSpan.styles(fromRaw: styles, text: self.text)
         } else {
@@ -45,23 +43,15 @@ struct Line {
     }
 
     init?(updateFromJson line: Line?, json: [String: AnyObject]) {
-        if let line = line {
-            self.text = line.text
-            if let cursor = json["cursor"] as? [Int] {
-                self.cursor = cursor
-            } else {
-                self.cursor = line.cursor
-            }
-            if let styles = json["styles"] as? [Int] {
-                self.styles = StyleSpan.styles(fromRaw: styles, text: self.text)
-            } else {
-                self.styles = line.styles
-            }
+        guard let line = line else { return nil }
+        self.text = line.text
+        cursor = json["cursor"] as? [Int] ?? line.cursor
+        if let styles = json["styles"] as? [Int] {
+            self.styles = StyleSpan.styles(fromRaw: styles, text: self.text)
         } else {
-            return nil
+            self.styles = line.styles
         }
     }
-
 }
 
 /// A data structure holding a cache of lines, with methods for updating based
@@ -92,7 +82,7 @@ class LineCache {
         }
         return nil
     }
-
+    
     func applyUpdate(update: [String: Any]) {
         guard let ops = update["ops"] else { return }
         var newInvalidBefore = 0

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -38,14 +38,29 @@
                                     <rect key="frame" x="1" y="1" width="478" height="268"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="rTT-RO-I3T" customClass="EditView" customModule="XiEditor" customModuleProvider="target">
+                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="rTT-RO-I3T">
                                             <rect key="frame" x="0.0" y="0.0" width="478" height="268"/>
+                                            <subviews>
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="3Js-0o-jqZ" customClass="GutterView" customModule="XiEditor" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="0.0" width="20" height="268"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="20" id="Smj-nI-f5r"/>
+                                                    </constraints>
+                                                </customView>
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="q1P-kd-995" customClass="EditView" customModule="XiEditor" customModuleProvider="target">
+                                                    <rect key="frame" x="20" y="0.0" width="458" height="268"/>
+                                                </customView>
+                                            </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="268" id="Saf-eA-IEJ"/>
+                                                <constraint firstItem="q1P-kd-995" firstAttribute="leading" secondItem="3Js-0o-jqZ" secondAttribute="trailing" id="LH9-Tc-TcJ"/>
+                                                <constraint firstAttribute="height" priority="900" constant="268" id="Saf-eA-IEJ"/>
+                                                <constraint firstAttribute="bottom" secondItem="q1P-kd-995" secondAttribute="bottom" id="anp-0j-jCG"/>
+                                                <constraint firstAttribute="trailing" secondItem="q1P-kd-995" secondAttribute="trailing" id="dC4-sm-7Xf"/>
+                                                <constraint firstItem="3Js-0o-jqZ" firstAttribute="leading" secondItem="rTT-RO-I3T" secondAttribute="leading" id="f7L-vN-ABi"/>
+                                                <constraint firstItem="q1P-kd-995" firstAttribute="top" secondItem="rTT-RO-I3T" secondAttribute="top" id="gJj-bF-tAE"/>
+                                                <constraint firstAttribute="bottom" secondItem="3Js-0o-jqZ" secondAttribute="bottom" id="kjU-1n-2Y5"/>
+                                                <constraint firstItem="3Js-0o-jqZ" firstAttribute="top" secondItem="rTT-RO-I3T" secondAttribute="top" id="ycq-Wi-XAC"/>
                                             </constraints>
-                                            <connections>
-                                                <outlet property="heightConstraint" destination="Saf-eA-IEJ" id="uZX-5F-hM2"/>
-                                            </connections>
                                         </customView>
                                     </subviews>
                                     <constraints>
@@ -63,7 +78,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
-                            <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c3r-nr-uYj" customClass="ShadowView" customModule="XiEditor" customModuleProvider="target">
+                            <customView hidden="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c3r-nr-uYj" customClass="ShadowView" customModule="XiEditor" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="1" width="481" height="270"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </customView>
@@ -77,7 +92,10 @@
                     </view>
                     <connections>
                         <outlet property="documentView" destination="1wJ-s5-kVO" id="6fc-8J-LwC"/>
-                        <outlet property="editView" destination="rTT-RO-I3T" id="YIl-Nk-fhb"/>
+                        <outlet property="editView" destination="q1P-kd-995" id="Dhz-gl-7Ut"/>
+                        <outlet property="editViewHeight" destination="Saf-eA-IEJ" id="oOC-Nd-tqI"/>
+                        <outlet property="gutterView" destination="3Js-0o-jqZ" id="BLh-Gh-ebk"/>
+                        <outlet property="gutterViewWidth" destination="Smj-nI-f5r" id="kjP-so-JhO"/>
                         <outlet property="scrollView" destination="Qwv-ci-fVA" id="4cE-10-pSP"/>
                         <outlet property="shadowView" destination="c3r-nr-uYj" id="X0D-a3-NVc"/>
                     </connections>

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -91,7 +91,6 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="documentView" destination="1wJ-s5-kVO" id="6fc-8J-LwC"/>
                         <outlet property="editView" destination="q1P-kd-995" id="Dhz-gl-7Ut"/>
                         <outlet property="editViewContainer" destination="rTT-RO-I3T" id="tpu-XX-c9T"/>
                         <outlet property="editViewHeight" destination="Saf-eA-IEJ" id="oOC-Nd-tqI"/>

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -32,14 +32,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="Qwv-ci-fVA">
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="Qwv-ci-fVA">
                                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                                 <clipView key="contentView" id="1wJ-s5-kVO">
-                                    <rect key="frame" x="1" y="1" width="478" height="268"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="rTT-RO-I3T" customClass="EditViewContainer" customModule="XiEditor" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="478" height="268"/>
+                                            <rect key="frame" x="0.0" y="2" width="480" height="268"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="3Js-0o-jqZ" customClass="GutterView" customModule="XiEditor" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="20" height="268"/>
@@ -48,7 +48,7 @@
                                                     </constraints>
                                                 </customView>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="q1P-kd-995" customClass="EditView" customModule="XiEditor" customModuleProvider="target">
-                                                    <rect key="frame" x="20" y="0.0" width="458" height="268"/>
+                                                    <rect key="frame" x="20" y="0.0" width="460" height="268"/>
                                                 </customView>
                                             </subviews>
                                             <constraints>
@@ -78,7 +78,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
-                            <customView hidden="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c3r-nr-uYj" customClass="ShadowView" customModule="XiEditor" customModuleProvider="target">
+                            <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c3r-nr-uYj" customClass="ShadowView" customModule="XiEditor" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="1" width="481" height="270"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </customView>

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -38,7 +38,7 @@
                                     <rect key="frame" x="1" y="1" width="478" height="268"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="rTT-RO-I3T">
+                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="rTT-RO-I3T" customClass="EditViewContainer" customModule="XiEditor" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="478" height="268"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="3Js-0o-jqZ" customClass="GutterView" customModule="XiEditor" customModuleProvider="target">
@@ -93,6 +93,7 @@
                     <connections>
                         <outlet property="documentView" destination="1wJ-s5-kVO" id="6fc-8J-LwC"/>
                         <outlet property="editView" destination="q1P-kd-995" id="Dhz-gl-7Ut"/>
+                        <outlet property="editViewContainer" destination="rTT-RO-I3T" id="tpu-XX-c9T"/>
                         <outlet property="editViewHeight" destination="Saf-eA-IEJ" id="oOC-Nd-tqI"/>
                         <outlet property="gutterView" destination="3Js-0o-jqZ" id="BLh-Gh-ebk"/>
                         <outlet property="gutterViewWidth" destination="Smj-nI-f5r" id="kjP-so-JhO"/>

--- a/XiEditor/ShadowView.swift
+++ b/XiEditor/ShadowView.swift
@@ -13,15 +13,13 @@
 // limitations under the License.
 
 import Cocoa
-
+/// A custom view that draws a shadow over the editView when content is clipped.
+/// Note: - if we ever move to layer-based drawing this should be handled by a layer on the EditViewContainer
 class ShadowView: NSView {
-    var topShadow = false
-    var leadingShadow = false
-    var trailingShadow = false
+    private var topShadow = false
+    private var leadingShadow = false
+    private var trailingShadow = false
     
-    var mouseUpHandler: ((NSEvent) -> Void)?
-    var mouseDraggedHandler: ((NSEvent) -> Void)?
-
     override func draw(_ dirtyRect: NSRect) {
         if topShadow || leadingShadow || trailingShadow {
             let context = NSGraphicsContext.current()!.cgContext
@@ -44,11 +42,16 @@ class ShadowView: NSView {
     override var isFlipped: Bool {
         return true;
     }
-
+    
+    // shadow view shouldn't receive mouse events
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        return nil
+    }
+    
     func updateScroll(_ contentBounds: NSRect, _ docBounds: NSRect) {
         let newTop = contentBounds.origin.y != 0
         let newLead = contentBounds.origin.x != 0
-        let newTrail = contentBounds.origin.x + contentBounds.width != docBounds.origin.x + docBounds.width
+        let newTrail = NSMaxX(contentBounds) < NSMaxX(docBounds)
         if newTop != topShadow || newLead != leadingShadow || newTrail != trailingShadow {
             needsDisplay = true
             topShadow = newTop
@@ -56,13 +59,4 @@ class ShadowView: NSView {
             trailingShadow = newTrail
         }
     }
-
-    override func mouseDragged(with theEvent: NSEvent) {
-        mouseDraggedHandler?(theEvent)
-    }
-
-    override func mouseUp(with theEvent: NSEvent) {
-        mouseUpHandler?(theEvent)
-    }
-
 }


### PR DESCRIPTION
Here's a little first shot at doing line numbers. This is more or less the simplest reasonable implementation I could come up with.

This PR also includes some continued work on moving interaction & general drawing logic from the `EditView` to the `EditViewController`.

Some issues that have occurred to me through this process, which I'll open separately: 

1. This would be a good time to think about support for theming, and the division of responsibilities there. 

2. I'd like to think about horizontal scrolling. When not using word-wrap it feels like horizontal scrolling could be at the discretion of the front-end; the core doesn't need to have any knowledge of the width of the view. In any case, I'd want to think about the relationship between horizontal scrolling and the gutter view. I'm thinking of Sublime's behaviour (the gutter floats in place during hscroll) as a reference.

3. I'd like to think about user preferences; again there might be some division of responsibilities between the frontend and the core here. If line-wrap is a preference then core needs to know about it, but font size maybe not so much.


Anyway that can all get fleshed out more in issues. Let me know if you have any thoughts or concerns about my approach here.


This closes https://github.com/google/xi-editor/issues/175.