### PR TITLE
Stop treating document as an optional

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
 		6B0DCDD41E8196D0007C14A3 /* GutterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD31E8196D0007C14A3 /* GutterView.swift */; };
-		6B0DCDD61E832101007C14A3 /* EditViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD51E832101007C14A3 /* EditViewContainer.swift */; };
+		6B0DCDD61E832101007C14A3 /* EditContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD51E832101007C14A3 /* EditContainerView.swift */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -53,7 +53,7 @@
 /* Begin PBXFileReference section */
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		6B0DCDD31E8196D0007C14A3 /* GutterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutterView.swift; sourceTree = "<group>"; };
-		6B0DCDD51E832101007C14A3 /* EditViewContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditViewContainer.swift; sourceTree = "<group>"; };
+		6B0DCDD51E832101007C14A3 /* EditContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditContainerView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "xi-syntect-plugin"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -70,10 +70,10 @@
 		AE499DEA1C82BB2B002D68AF /* XiEditorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiEditorUITests.swift; sourceTree = "<group>"; };
 		AE499DEC1C82BB2B002D68AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AE499DF81C82C835002D68AF /* CoreConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreConnection.swift; sourceTree = "<group>"; };
-		AEB66A781CAEFC8F002F686A /* ShadowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowView.swift; sourceTree = "<group>"; };
+		AEB66A781CAEFC8F002F686A /* ShadowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ShadowView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		AED23F171C83CBEC002246CE /* EditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
 		F53EA2AC1DCAA8110071ACFD /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
+		F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		F5BDBF361DCA9D2C0042430B /* Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -128,7 +128,7 @@
 			children = (
 				F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */,
 				6B0DCDD31E8196D0007C14A3 /* GutterView.swift */,
-				6B0DCDD51E832101007C14A3 /* EditViewContainer.swift */,
+				6B0DCDD51E832101007C14A3 /* EditContainerView.swift */,
 				AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */,
 				AED23F171C83CBEC002246CE /* EditView.swift */,
 				AEB66A781CAEFC8F002F686A /* ShadowView.swift */,
@@ -182,7 +182,7 @@
 			buildPhases = (
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = xi-editor/rust;
+			buildWorkingDirectory = "xi-editor/rust";
 			dependencies = (
 			);
 			name = xicore;
@@ -330,7 +330,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F53EA2AF1DCAAA170071ACFD /* EditViewController.swift in Sources */,
-				6B0DCDD61E832101007C14A3 /* EditViewContainer.swift in Sources */,
+				6B0DCDD61E832101007C14A3 /* EditContainerView.swift in Sources */,
 				AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */,
 				AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */,
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,

--- a/XiEditor/EditContainerView.swift
+++ b/XiEditor/EditContainerView.swift
@@ -14,7 +14,7 @@
 
 import Cocoa
 
-class EditViewContainer: NSView {
+class EditContainerView: NSView {
 
     override var isFlipped: Bool {
         return true

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -91,7 +91,6 @@ func camelCaseToUnderscored(_ name: NSString) -> NSString {
 }
 
 class EditView: NSView, NSTextInputClient {
-    var document: Document!
     var dataSource: EditViewDataSource!
 
     var textSelectionColor: NSColor {
@@ -156,7 +155,7 @@ class EditView: NSView, NSTextInputClient {
     let font_style_italic: Int = 4;
 
     override func draw(_ dirtyRect: NSRect) {
-        if document?.tabName == nil { return }
+        if dataSource.document.tabName == nil { return }
         super.draw(dirtyRect)
         /*
         let path = NSBezierPath(ovalInRect: frame)
@@ -174,7 +173,7 @@ class EditView: NSView, NSTextInputClient {
         let missing = dataSource.lines.computeMissing(first, last)
         for (f, l) in missing {
             Swift.print("requesting missing: \(f)..\(l)")
-            document?.sendRpcAsync("request_lines", params: [f, l])
+            dataSource.document.sendRpcAsync("request_lines", params: [f, l])
         }
 
         // first pass, for drawing background selections
@@ -302,12 +301,12 @@ class EditView: NSView, NSTextInputClient {
             replacementRange.length = 0
         }
         for _ in 0..<aRange.length {
-            document?.sendRpcAsync("delete_backward", params  : [])
+            dataSource.document.sendRpcAsync("delete_backward", params  : [])
         }
         if let attrStr = aString as? NSAttributedString {
-            document?.sendRpcAsync("insert", params: insertedStringToJson(attrStr.string as NSString))
+            dataSource.document.sendRpcAsync("insert", params: insertedStringToJson(attrStr.string as NSString))
         } else if let str = aString as? NSString {
-            document?.sendRpcAsync("insert", params: insertedStringToJson(str))
+            dataSource.document.sendRpcAsync("insert", params: insertedStringToJson(str))
         }
         return NSMakeRange(replacementRange.location, len)
     }
@@ -328,7 +327,7 @@ class EditView: NSView, NSTextInputClient {
     func removeMarkedText() {
         if (_markedRange.location != NSNotFound) {
             for _ in 0..<_markedRange.length {
-                document?.sendRpcAsync("delete_backward", params: [])
+                dataSource.document.sendRpcAsync("delete_backward", params: [])
             }
         }
         _markedRange = NSMakeRange(NSNotFound, 0)
@@ -385,7 +384,7 @@ class EditView: NSView, NSTextInputClient {
             if (commandName == "noop") {
                 NSBeep()
             } else {
-                document?.sendRpcAsync(commandName, params: []);
+                dataSource.document.sendRpcAsync(commandName, params: []);
             }
         }
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -29,7 +29,7 @@ class EditViewController: NSViewController, EditViewDataSource {
     
     @IBOutlet var shadowView: ShadowView!
     @IBOutlet var scrollView: NSScrollView!
-    @IBOutlet weak var editViewContainer: EditViewContainer!
+    @IBOutlet weak var editContainerView: EditContainerView!
     @IBOutlet var editView: EditView!
     @IBOutlet weak var gutterView: GutterView!
     
@@ -128,7 +128,7 @@ class EditViewController: NSViewController, EditViewDataSource {
         let x = CGFloat(col) * textMetrics.fontWidth  // TODO: deal with non-ASCII, non-monospaced case
         let y = CGFloat(line) * textMetrics.linespace + textMetrics.baseline
         let scrollRect = NSRect(x: x, y: y - textMetrics.baseline, width: 4, height: textMetrics.linespace + textMetrics.descent)
-        editViewContainer.scrollToVisible(scrollRect)
+        editContainerView.scrollToVisible(scrollRect)
     }
     
     // MARK: - System Events

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -20,6 +20,7 @@ protocol EditViewDataSource {
     var styleMap: StyleMap { get }
     var textMetrics: TextDrawingMetrics { get }
     var gutterWidth: CGFloat { get }
+    var document: Document! { get }
 }
 
 
@@ -35,11 +36,7 @@ class EditViewController: NSViewController, EditViewDataSource {
     @IBOutlet weak var gutterViewWidth: NSLayoutConstraint!
     @IBOutlet weak var editViewHeight: NSLayoutConstraint!
     
-    var document: Document! {
-        didSet {
-            editView.document = document
-        }
-    }
+    var document: Document!
     
     var lines: LineCache = LineCache()
     var styleMap: StyleMap {
@@ -110,7 +107,7 @@ class EditViewController: NSViewController, EditViewDataSource {
         if first != firstLine || last != lastLine && document != nil {
             firstLine = first
             lastLine = last
-            document?.sendRpcAsync("scroll", params: [firstLine, lastLine])
+            document.sendRpcAsync("scroll", params: [firstLine, lastLine])
         }
         shadowView?.updateScroll(scrollView.contentView.bounds, scrollView.documentView!.bounds)
         // if the window is resized, update the editViewHeight so we don't show scrollers unnecessarily
@@ -157,7 +154,7 @@ class EditViewController: NSViewController, EditViewDataSource {
         if let last = lastDragPosition, last != dragPosition {
             lastDragPosition = dragPosition
             let flags = theEvent.modifierFlags.rawValue >> 16
-            document?.sendRpcAsync("drag", params: [last.line, last.column, flags])
+            document.sendRpcAsync("drag", params: [last.line, last.column, flags])
         }
         dragEvent = theEvent
     }
@@ -176,7 +173,7 @@ class EditViewController: NSViewController, EditViewDataSource {
     
     // NSResponder (used mostly for paste)
     override func insertText(_ insertString: Any) {
-        document?.sendRpcAsync("insert", params: insertedStringToJson(insertString as! NSString))
+        document.sendRpcAsync("insert", params: insertedStringToJson(insertString as! NSString))
     }
 
     // we intercept this method to check if we should open a new tab
@@ -240,24 +237,24 @@ class EditViewController: NSViewController, EditViewDataSource {
     }
     
     func undo(_ sender: AnyObject?) {
-        document?.sendRpcAsync("undo", params: [])
+        document.sendRpcAsync("undo", params: [])
     }
     
     func redo(_ sender: AnyObject?) {
-        document?.sendRpcAsync("redo", params: [])
+        document.sendRpcAsync("redo", params: [])
     }
 
     // MARK: - Debug Methods
     @IBAction func debugRewrap(_ sender: AnyObject) {
-        document?.sendRpcAsync("debug_rewrap", params: [])
+        document.sendRpcAsync("debug_rewrap", params: [])
     }
     
     @IBAction func debugTestFGSpans(_ sender: AnyObject) {
-        document?.sendRpcAsync("debug_test_fg_spans", params: [])
+        document.sendRpcAsync("debug_test_fg_spans", params: [])
     }
     
     @IBAction func debugRunPlugin(_ sender: AnyObject) {
-        document?.sendRpcAsync("debug_run_plugin", params: [])
+        document.sendRpcAsync("debug_run_plugin", params: [])
     }
 }
 

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -38,7 +38,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="rTT-RO-I3T" customClass="EditViewContainer" customModule="XiEditor" customModuleProvider="target">
+                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="rTT-RO-I3T" customClass="EditContainerView" customModule="XiEditor" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="2" width="480" height="268"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="3Js-0o-jqZ" customClass="GutterView" customModule="XiEditor" customModuleProvider="target">
@@ -91,8 +91,8 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="editContainerView" destination="rTT-RO-I3T" id="V33-lc-vP3"/>
                         <outlet property="editView" destination="q1P-kd-995" id="Dhz-gl-7Ut"/>
-                        <outlet property="editViewContainer" destination="rTT-RO-I3T" id="tpu-XX-c9T"/>
                         <outlet property="editViewHeight" destination="Saf-eA-IEJ" id="oOC-Nd-tqI"/>
                         <outlet property="gutterView" destination="3Js-0o-jqZ" id="BLh-Gh-ebk"/>
                         <outlet property="gutterViewWidth" destination="Smj-nI-f5r" id="kjP-so-JhO"/>

--- a/XiEditor/ShadowView.swift
+++ b/XiEditor/ShadowView.swift
@@ -14,7 +14,7 @@
 
 import Cocoa
 /// A custom view that draws a shadow over the editView when content is clipped.
-/// Note: - if we ever move to layer-based drawing this should be handled by a layer on the EditViewContainer
+/// Note: - if we ever move to layer-based drawing this should be handled by a layer on the EditContainerView
 class ShadowView: NSView {
     private var topShadow = false
     private var leadingShadow = false


### PR DESCRIPTION
This is something that had bit me last week when I was playing around with some other drawing changes. By treating the document as an optional we were failing silently if we tried to send an RPC while it was `nil`. I think it's better if we crash in that situation.
