### PR TITLE
fix drawing flicker in newly loaded documents

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -78,9 +78,14 @@ class EditViewController: NSViewController, EditViewDataSource {
         editView.dataSource = self
         gutterView.dataSource = self
         scrollView.contentView.documentCursor = NSCursor.iBeam();
-        
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.boundsDidChangeNotification(_:)), name: NSNotification.Name.NSViewBoundsDidChange, object: scrollView.contentView)
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSNotification.Name.NSViewFrameDidChange, object: scrollView)
+        // call to set initial scroll position once we know view size
+        updateEditViewScroll()
     }
 
     // this gets called when the user changes the font with the font book, for example
@@ -107,7 +112,7 @@ class EditViewController: NSViewController, EditViewDataSource {
         let first = Int(floor(scrollView.contentView.bounds.origin.y / textMetrics.linespace))
         let height = Int(ceil((scrollView.contentView.bounds.size.height) / textMetrics.linespace))
         let last = first + height
-        if first != firstLine || last != lastLine && document != nil {
+        if first != firstLine || last != lastLine {
             firstLine = first
             lastLine = last
             document?.sendRpcAsync("scroll", params: [firstLine, lastLine])


### PR DESCRIPTION
This fixes an issue where drawing would flicker in a freshly loaded window, because the frontend was not correctly reporting its size to the core.