### PR TITLE
Intercept option-arrow events

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -141,8 +141,24 @@ class EditViewController: NSViewController, EditViewDataSource {
     }
     
     // MARK: - System Events
+
     override func keyDown(with theEvent: NSEvent) {
-        self.editView.inputContext?.handleEvent(theEvent);
+        switch theEvent.keyCode {
+        case 125 where shouldInterceptEvent(event: theEvent):
+            self.editView.doCommand(by: #selector(NSResponder.moveToEndOfParagraph(_:)))
+        case 126 where shouldInterceptEvent(event: theEvent):
+            self.editView.doCommand(by: #selector(NSResponder.moveToBeginningOfParagraph(_:)))
+        default:
+            self.editView.inputContext?.handleEvent(theEvent);
+        }
+    }
+    
+    // HACK: we intercept option-arrow events to override default system
+    // behaviour, which is to send two consecutive events.
+    // See https://github.com/google/xi-mac/issues/14#issuecomment-294324523
+    private func shouldInterceptEvent(event: NSEvent) -> Bool {
+        // arrow keys apparently send .function and .numeric, and some bottom bits are being set by something else? This isn't pretty but at least I'm reasonably confidient it does what I want
+        return event.modifierFlags.contains(.option) && event.modifierFlags.isDisjoint(with: [.control, .shift, .command])
     }
     
     override func mouseDown(with theEvent: NSEvent) {


### PR DESCRIPTION
This fixes the issue with sending duplicate events, and introduces the _new_ issue that Xi's behaviour on macOS is no longer in line with system idioms, e.g. we don't move down by a new paragraph when we send `moveToEndOfParagraph:` and the cursor is currently at the end of a paragraph.

This maybe asks questions about prioritizing consistency of internal editor behaviour versus respect for platform idioms? I'm probably overthinking this.

I probably wouldn't merge this as-is. If we want to go this route, we should update xi-core to recreate the previous behaviour. Might be a fun one for @cbrewster?