### PR TITLE
Fixed IME support issue

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -204,6 +204,8 @@ class EditView: NSView, NSTextInputClient {
             dataSource.styleMap.applyStyles(text: s, string: &attrString, styles: line.styles)
             for c in line.cursor {
                 let cix = utf8_offset_to_utf16(s, c)
+                // TODO: How should we handle the situations that have multi-cursor?
+                self.cursorPos = (lineIx, cix)
                 if (markedRange().location != NSNotFound) {
                     let markRangeStart = cix - markedRange().length
                     if (markRangeStart >= 0) {


### PR DESCRIPTION
Related issue: #18 

Fixed by updating `cursorPos` in `draw` method.

![2017-04-18_15-41-07](https://cloud.githubusercontent.com/assets/15538025/25119703/d7f3e134-244d-11e7-83ce-fa67204cfa53.gif)
