### PR TITLE
Ensure that Document.close() is only called once

### DIFF
--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -150,13 +150,12 @@ class Document: NSDocument {
         //TODO: save operations should report success, and we should pass any errors to the completion handler
         completionHandler(nil)
     }
-    
+
     // Document.close() can be called multiple times (on window close and application terminate)
-    fileprivate var _isClosed = false
     override func close() {
-        if !self._isClosed {
-            self._isClosed = true
-            Events.CloseView(viewIdentifier: coreViewIdentifier!).dispatch(dispatcher!)
+        if let identifier = self.coreViewIdentifier {
+            self.coreViewIdentifier = nil
+            Events.CloseView(viewIdentifier: identifier).dispatch(dispatcher!)
             super.close()
         }
     }

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -151,9 +151,14 @@ class Document: NSDocument {
         completionHandler(nil)
     }
     
+    // Document.close() can be called multiple times (on window close and application terminate)
+    fileprivate var _isClosed = false
     override func close() {
-        super.close()
-        Events.CloseView(viewIdentifier: coreViewIdentifier!).dispatch(dispatcher!)
+        if !self._isClosed {
+            self._isClosed = true
+            Events.CloseView(viewIdentifier: coreViewIdentifier!).dispatch(dispatcher!)
+            super.close()
+        }
     }
     
     override var isEntireFileLoaded: Bool {


### PR DESCRIPTION
After sleeping on it I think this is the cleanest approach. I'm thinking about how multi-view is going to work, but I don't think that's really relevant here.

closes #25