### PR TITLE
Don't delete marked text when mouse down

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -152,7 +152,7 @@ class EditViewController: NSViewController, EditViewDataSource {
     }
     
     override func mouseDown(with theEvent: NSEvent) {
-        editView.removeMarkedText()
+        editView.unmarkText()
         editView.inputContext?.discardMarkedText()
         let position  = editView.bufferPositionFromPoint(theEvent.locationInWindow)
         lastDragPosition = position


### PR DESCRIPTION
Follows the behavior of Xcode, Chrome, Safari, etc.

I think we should follow majority in this situation, in order to fit
users’ expectation when they mouse down with marked text.