### PR TITLE
Discard marked text when select all

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -192,6 +192,8 @@ class EditViewController: NSViewController, EditViewDataSource {
     }
 
     override func selectAll(_ sender: Any?) {
+        editView.unmarkText()
+        editView.inputContext?.discardMarkedText()
         document.sendRpcAsync("select_all", params: [])
     }
 


### PR DESCRIPTION
Follows the behavior of Xcode.

In current implementatuion, we don’t discard or unmark the text when
user perform select all. If user select a word from input box, then
entire selection will be replaced by the selected word. That is an
incorrect behaviour.

If we want to keep marked text after select all, the correct behavior
is that only the marked text is replaced by the selected word, but not
entire selection. However, I find no example app that keep marked text
while performing select all

In Chrome or Safari, they disable select all if there is marked text.
In Xcode, marked text will be discard after select all.

I am doubt that is there a need to keep marked text after select all,
because most apps don’t do that.

On the other hand, I think it would be better to follow Xcode’s
behavior instead of Browsers, because we are an editor.

So this patch attempts to follow Xcode’s behavior, discard marked text
when select all.