### PR TITLE
Add handling for incoming RPC requests

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -27,8 +27,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             else { fatalError("XI Core not found") }
 
         let dispatcher: Dispatcher = {
-            let coreConnection = CoreConnection(path: corePath) { [weak self] (json: Any) -> Void in
-                self?.handleCoreCmd(json)
+            let coreConnection = CoreConnection(path: corePath) { [weak self] (json: Any) -> Any? in
+                return self?.handleCoreCmd(json)
             }
 
             return Dispatcher(coreConnection: coreConnection)
@@ -48,28 +48,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return nil
     }
 
-    func handleCoreCmd(_ json: Any) {
+    func handleCoreCmd(_ json: Any) -> Any? {
         guard let obj = json as? [String : Any],
             let method = obj["method"] as? String,
             let params = obj["params"]
-            else { print("unknown json from core:", json); return }
+            else { print("unknown json from core:", json); return nil }
 
-        handleRpc(method, params: params)
+        return handleRpc(method, params: params)
     }
 
-    func handleRpc(_ method: String, params: Any) {
+    func handleRpc(_ method: String, params: Any) -> Any? {
         switch method {
         case "update":
             if let obj = params as? [String : AnyObject], let update = obj["update"] as? [String : AnyObject] {
                 guard
                     let viewIdentifier = obj["view_id"] as? String, let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
-                    else { print("view_id or document missing for update event: ", obj); return }
+                    else { print("view_id or document missing for update event: ", obj); return nil }
                     document.update(update)
             }
         case "scroll_to":
             if let obj = params as? [String : AnyObject], let line = obj["line"] as? Int, let col = obj["col"] as? Int {
                 guard let viewIdentifier = obj["view_id"] as? String, let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
-                    else { print("view_id or document missing for update event: ", obj); return }
+                    else { print("view_id or document missing for update event: ", obj); return nil }
                     document.editViewController?.scrollTo(line, col)
             }
         case "def_style":
@@ -86,6 +86,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         default:
             print("unknown method from core:", method)
         }
+
+        return nil
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -96,7 +96,7 @@ class CoreConnection {
     func handleRpc(_ json: Any) {
         if let obj = json as? [String: Any], let index = obj["id"] as? Int {
             if let result = obj["result"] { // is response
-                var callback: ((Any?) -> ())? = nil
+                var callback: ((Any?) -> ())?
                 queue.sync {
                     callback = self.pending.removeValue(forKey: index)
                 }

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -18,14 +18,14 @@ class CoreConnection {
 
     var inHandle: FileHandle  // stdin of core process
     var recvBuf: Data
-    var callback: (AnyObject) -> ()
+    var callback: (Any) -> Any?
 
     // RPC state
     var queue = DispatchQueue(label: "com.levien.xi.CoreConnection", attributes: [])
     var rpcIndex = 0
     var pending = Dictionary<Int, (Any?) -> ()>()
 
-    init(path: String, callback: @escaping (Any) -> ()) {
+    init(path: String, callback: @escaping (Any) -> Any?) {
         let task = Process()
         task.launchPath = path
         task.arguments = []
@@ -84,14 +84,34 @@ class CoreConnection {
     func handleRaw(_ data: Data) {
         do {
             let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-            //print("got \(json)")
-            if !handleRpcResponse(json as AnyObject) {
+//            print("got \(json)")
+            handleRpc(json as Any)
+        } catch {
+            print("json error \(error.localizedDescription)")
+        }
+    }
+
+    /// handle a JSON RPC call. Determines whether it is a request, response or notifcation
+    /// and executes/responds accordingly
+    func handleRpc(_ json: Any) {
+        if let obj = json as? [String: Any], let index = obj["id"] as? Int {
+            if let result = obj["result"] { // is response
+                var callback: ((Any?) -> ())? = nil
+                queue.sync {
+                    callback = self.pending.removeValue(forKey: index)
+                }
+                callback?(result)
+            } else { // is request
                 DispatchQueue.main.async {
-                    self.callback(json as AnyObject)
+                    let result = self.callback(json as AnyObject)
+                    let resp = ["id": index, "result": result] as [String : Any?]
+                    self.sendJson(resp as Any)
                 }
             }
-        } catch _ {
-            print("json error")
+        } else { // is notification
+            DispatchQueue.main.async {
+                let _ = self.callback(json as AnyObject)
+            }
         }
     }
 
@@ -122,19 +142,5 @@ class CoreConnection {
         }
         let _ = semaphore.wait(timeout: DispatchTime.distantFuture)
         return result
-    }
-
-    func handleRpcResponse(_ response: Any) -> Bool {
-        if let resp = response as? [String: Any], let index = resp["id"] as? Int {
-            var callback: ((Any?) -> ())? = nil
-            let result = resp["result"]
-            queue.sync {
-                callback = self.pending.removeValue(forKey: index)
-            }
-            callback?(result)
-            return true;
-        } else {
-            return false;
-        }
     }
 }


### PR DESCRIPTION
Instead of handling every incoming JSON RPC call as either a notification
or a response, the frontend is now also able to properly handle requests.