### PR TITLE
Use font based on italic and font weight settings

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -14,16 +14,16 @@
 
 import Cocoa
 
-//TODO: preferred font should be a user preference
-let defaultFont = CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil)
-
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     var dispatcher: Dispatcher?
 
-    var textMetrics = TextDrawingMetrics(font: defaultFont)
-    var styleMap: StyleMap = StyleMap(font: defaultFont)
+    //TODO: preferred font should be a user preference
+    let defaultFont = CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil)
+
+    lazy var textMetrics: TextDrawingMetrics = TextDrawingMetrics(font: self.defaultFont)
+    lazy var styleMap: StyleMap = StyleMap(font: self.defaultFont)
 
     func applicationWillFinishLaunching(_ aNotification: Notification) {
 
@@ -105,6 +105,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             guard let doc = doc as? Document else { continue }
             doc.editViewController?.updateGutterWidth()
             doc.editViewController?.editView.needsDisplay = true
+            doc.editViewController?.updateEditViewScroll()
         }
     }
 

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -42,19 +42,13 @@ struct TextDrawingMetrics {
     
     init(font: NSFont) {
         self.font = font
-        ascent = CTFontGetAscent(font)
-        descent = CTFontGetDescent(font)
-        leading = CTFontGetLeading(font)
+        ascent = font.ascender
+        descent = abs(font.descender)
+        leading = font.leading
         linespace = ceil(ascent + descent + leading)
         baseline = ceil(ascent)
         fontWidth = font.characterWidth()
-        attributes[String(kCTFontAttributeName)] = font
-    }
-    
-    /// Passed an NSFontManager instance (as on a user-initiated font change) computes the next set of drawing metrics.
-    func newMetricsForFontChange(fontManager: NSFontManager) -> TextDrawingMetrics {
-        let newFont = fontManager.convert(font)
-        return TextDrawingMetrics(font: newFont)
+        attributes[NSFontAttributeName] = font
     }
 }
 
@@ -97,7 +91,7 @@ class EditView: NSView, NSTextInputClient {
         if self.isFrontmostView {
             return NSColor.selectedTextBackgroundColor
         } else {
-        return NSColor(colorLiteralRed: 0.8, green: 0.8, blue: 0.8, alpha: 1.0)
+            return NSColor(colorLiteralRed: 0.8, green: 0.8, blue: 0.8, alpha: 1.0)
         }
     }
 
@@ -149,10 +143,6 @@ class EditView: NSView, NSTextInputClient {
     }
 
     let x0: CGFloat = 2;
-
-    let font_style_bold: Int = 1;
-    let font_style_underline: Int = 2;
-    let font_style_italic: Int = 4;
 
     override func draw(_ dirtyRect: NSRect) {
         if dataSource.document.coreViewIdentifier == nil { return }

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -43,7 +43,7 @@ struct TextDrawingMetrics {
     init(font: NSFont) {
         self.font = font
         ascent = font.ascender
-        descent = abs(font.descender)
+        descent = -font.descender // descender is returned as a negative number
         leading = font.leading
         linespace = ceil(ascent + descent + leading)
         baseline = ceil(ascent)

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -109,7 +109,7 @@ class EditViewController: NSViewController, EditViewDataSource {
         updateEditViewScroll()
     }
 
-    fileprivate func updateEditViewScroll() {
+    func updateEditViewScroll() {
         let first = Int(floor(scrollView.contentView.bounds.origin.y / textMetrics.linespace))
         let height = Int(ceil((scrollView.contentView.bounds.size.height) / textMetrics.linespace))
         let last = first + height

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -39,13 +39,14 @@ class EditViewController: NSViewController, EditViewDataSource {
     var document: Document!
     
     var lines: LineCache = LineCache()
+
+    var textMetrics: TextDrawingMetrics {
+        return (NSApplication.shared().delegate as! AppDelegate).textMetrics
+    }
     var styleMap: StyleMap {
         return (NSApplication.shared().delegate as! AppDelegate).styleMap
     }
 
-    //TODO: preferred font should be a user preference
-    var textMetrics = TextDrawingMetrics(font: CTFontCreateWithName("InconsolataGo" as CFString?, 14, nil))
-    
     var gutterWidth: CGFloat {
         return gutterViewWidth.constant
     }
@@ -87,9 +88,7 @@ class EditViewController: NSViewController, EditViewDataSource {
     // this gets called when the user changes the font with the font book, for example
     override func changeFont(_ sender: Any?) {
         if let manager = sender as? NSFontManager {
-            textMetrics = textMetrics.newMetricsForFontChange(fontManager: manager)
-            updateGutterWidth()
-            self.editView.needsDisplay = true
+            (NSApplication.shared().delegate as! AppDelegate).handleFontChange(fontManager: manager)
         } else {
             Swift.print("changeFont: called with nil")
             return
@@ -98,7 +97,8 @@ class EditViewController: NSViewController, EditViewDataSource {
 
     func updateGutterWidth() {
         let gutterColumns = "\(lineCount)".characters.count
-        gutterViewWidth.constant = textMetrics.fontWidth * max(2, CGFloat(gutterColumns)) + 2 * gutterView.xPadding
+        let chWidth = NSString(string: "9").size(withAttributes: textMetrics.attributes).width
+        gutterViewWidth.constant = chWidth * max(2, CGFloat(gutterColumns)) + 2 * gutterView.xPadding
     }
     
     func boundsDidChangeNotification(_ notification: Notification) {

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -16,11 +16,55 @@ import Cocoa
 
 /// A represents a given text style.
 struct Style {
-    var fgColor: NSColor;
-    var bgColor: NSColor;
-    var weight: UInt16;
-    var underline: Bool;
-    var italic: Bool;
+    var font: NSFont?
+    var fgColor: NSColor?
+    var bgColor: NSColor?
+    var underline: Bool
+    var italic: Bool
+    var weight: Int?
+    var attributes: [String: Any] = [:]
+
+    init(font fromFont: NSFont, fgColor: NSColor?, bgColor: NSColor?, underline: Bool, italic: Bool, weight: Int?) {
+        if let fgColor = fgColor {
+            attributes[NSForegroundColorAttributeName] = fgColor
+        }
+
+        if let bgColor = bgColor, bgColor.alphaComponent != 0.0 {
+            attributes[NSBackgroundColorAttributeName] = bgColor
+        }
+
+        if underline {
+            attributes[NSUnderlineStyleAttributeName] = NSUnderlineStyle.styleSingle.rawValue
+        }
+
+        let fm = NSFontManager.shared()
+        var font: NSFont?
+
+        if italic {
+            var traits = fm.traits(of: fromFont)
+            traits.insert(NSFontTraitMask.italicFontMask)
+            if let f = closestMatch(of: fromFont, traits: traits, weight: weight ?? fm.weight(of: fromFont)) {
+                font = f
+            } else {
+                attributes[NSObliquenessAttributeName] = 0.2
+            }
+        }
+
+        if font == nil && weight != nil {
+            font = closestMatch(of: fromFont, traits: fm.traits(of: fromFont), weight: weight!) ?? fromFont
+        }
+
+        if let font = font {
+            attributes[NSFontAttributeName] = font
+        }
+
+        self.font = font
+        self.fgColor = fgColor
+        self.bgColor = bgColor
+        self.underline = underline
+        self.italic = italic
+        self.weight = weight
+    }
 }
 
 typealias StyleIdentifier = Int
@@ -45,7 +89,7 @@ struct StyleSpan {
                 //FIXME: how should we be doing error handling?
                 print("malformed style array for line:", text, raw)
             } else {
-                out.append(StyleSpan.init(range: NSMakeRange(startIx, endIx - startIx), style: style))
+                out.append(StyleSpan(range: NSMakeRange(startIx, endIx - startIx), style: style))
             }
             ix = end
         }
@@ -59,17 +103,28 @@ func utf8_offset_to_utf16(_ s: String, _ ix: Int) -> Int {
 
 /// A store of text styles, indexable by id.
 class StyleMap {
+    private var font: NSFont
     private var map: [Style?] = []
+
+    init(font: NSFont) {
+        self.font = font
+    }
 
     func defStyle(json: [String: AnyObject]) {
         guard let styleID = json["id"] as? Int else { return }
-        let fgColor = json["fg_color"] as? UInt32 ?? 0xFF000000
-        let bgColor = json["bg_color"] as? UInt32 ?? 0
-        let weight = json["weight"] as? UInt16 ?? 400
+
+        let fgColor = colorFromArgb(json["fg_color"] as? UInt32 ?? 0xFF000000)
+        let bgColor = colorFromArgb(json["bg_color"] as? UInt32 ?? 0)
         let underline = json["underline"] as? Bool ?? false
         let italic = json["italic"] as? Bool ?? false
+        var weight = json["weight"] as? Int
+        if let w = weight {
+            // convert to NSFont weight: (100-500 -> 2-6 (5 normal weight), 600-800 -> 8-10, 900 -> 12
+            weight = Int(floor(1 + Float(w) * (0.01 + 3e-6 * Float(w))))
+        }
         
-        let style = Style(fgColor: colorFromArgb(fgColor), bgColor: colorFromArgb(bgColor), weight: weight, underline: underline, italic: italic);
+        let style = Style(font: font, fgColor: fgColor, bgColor: bgColor,
+                          underline: underline, italic: italic, weight: weight)
         while map.count < styleID {
             map.append(nil)
         }
@@ -84,21 +139,8 @@ class StyleMap {
     private func applyStyle(string: NSMutableAttributedString, id: Int, range: NSRange) {
         if id >= map.count { return }
         guard let style = map[id] else { return }
-        string.addAttribute(NSForegroundColorAttributeName, value: style.fgColor, range: range)
-        if style.bgColor.alphaComponent != 0.0 {
-            string.addAttribute(NSBackgroundColorAttributeName, value: style.bgColor, range: range)
-        }
-        if style.underline {
-            string.addAttribute(NSUnderlineStyleAttributeName, value: NSUnderlineStyle.styleSingle.rawValue, range: range)
-        }
-        if style.weight > 500 {
-            // TODO: apply actual numeric weight
-            string.applyFontTraits(NSFontTraitMask.boldFontMask, range: range)
-        }
-        if style.italic {
-            // TODO: use true italic in font if available
-            string.addAttribute(NSObliquenessAttributeName, value: 0.2, range: range)
-        }
+
+        string.addAttributes(style.attributes, range: range)
     }
 
     /// Given style information, applies the appropriate text attributes to the passed NSAttributedString
@@ -108,4 +150,26 @@ class StyleMap {
                 applyStyle(string: string, id: styleSpan.style, range: styleSpan.range)
         }
     }
+
+    func updateFont(to font: NSFont) {
+        self.font = font
+        map = map.map { $0.map {
+            Style(font: font, fgColor: $0.fgColor, bgColor: $0.bgColor,
+                  underline: $0.underline, italic: $0.italic, weight: $0.weight)
+        } }
+    }
+}
+
+func closestMatch(of font: NSFont, traits: NSFontTraitMask, weight: Int) -> NSFont? {
+    let fm = NSFontManager.shared()
+    var weight = weight
+    let fromWeight = fm.weight(of: font)
+    let direction = fromWeight > weight ? 1 : -1
+    while weight != fromWeight {
+        if let f = fm.font(withFamily: font.familyName ?? font.fontName, traits: traits, weight: weight, size: font.pointSize) {
+            return f
+        }
+        weight += direction
+    }
+    return nil
 }


### PR DESCRIPTION
This PR is not ready, yet, but I'd like to have some feedback before continuing it (if continuing at all).

I've started working on the following code comments

```
// TODO: apply actual numeric weight
// TODO: use true italic in font if available
```

... and implemented the changes while keeping the future required string width calculation in mind.

The main concern is maybe that I made the `Style` struct font-aware. While this does work well for style-spans, it does not work well with the current `TextDrawingMetrics` that lives in the `EditViewController`. My feeling is that the `TextDrawingMetrics` could be replaced with a default Style (maybe Style 0 as the default style, and 1 the selection).