### PR TITLE
multi-plugin support

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
 		6B0DCDD41E8196D0007C14A3 /* GutterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD31E8196D0007C14A3 /* GutterView.swift */; };
 		6B0DCDD61E832101007C14A3 /* EditContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD51E832101007C14A3 /* EditContainerView.swift */; };
+		6B5138471EBD23C200C992A8 /* bracket_example.py in Resources */ = {isa = PBXBuildFile; fileRef = 6B5138441EBD23C200C992A8 /* bracket_example.py */; };
+		6B5138481EBD23C200C992A8 /* shouty.py in Resources */ = {isa = PBXBuildFile; fileRef = 6B5138451EBD23C200C992A8 /* shouty.py */; };
+		6B5138491EBD23C200C992A8 /* spellcheck.py in Resources */ = {isa = PBXBuildFile; fileRef = 6B5138461EBD23C200C992A8 /* spellcheck.py */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -54,6 +57,9 @@
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		6B0DCDD31E8196D0007C14A3 /* GutterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutterView.swift; sourceTree = "<group>"; };
 		6B0DCDD51E832101007C14A3 /* EditContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditContainerView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		6B5138441EBD23C200C992A8 /* bracket_example.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = bracket_example.py; path = "xi-editor/python/bracket_example.py"; sourceTree = SOURCE_ROOT; };
+		6B5138451EBD23C200C992A8 /* shouty.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = shouty.py; path = "xi-editor/python/shouty.py"; sourceTree = SOURCE_ROOT; };
+		6B5138461EBD23C200C992A8 /* spellcheck.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = spellcheck.py; path = "xi-editor/python/spellcheck.py"; sourceTree = SOURCE_ROOT; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "xi-syntect-plugin"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -168,6 +174,9 @@
 				AE041B971D4323460069AB8B /* build-rust-xcode.sh */,
 				AE228F5C1C897CE7000E9B0F /* xi-core */,
 				AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */,
+				6B5138441EBD23C200C992A8 /* bracket_example.py */,
+				6B5138451EBD23C200C992A8 /* shouty.py */,
+				6B5138461EBD23C200C992A8 /* spellcheck.py */,
 			);
 			name = xicore;
 			sourceTree = "<group>";
@@ -301,9 +310,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B5138491EBD23C200C992A8 /* spellcheck.py in Resources */,
 				F53EA2AD1DCAA8110071ACFD /* Main.storyboard in Resources */,
 				AE228F5D1C897CE7000E9B0F /* xi-core in Resources */,
+				6B5138471EBD23C200C992A8 /* bracket_example.py in Resources */,
 				AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */,
+				6B5138481EBD23C200C992A8 /* shouty.py in Resources */,
 				AE499DD21C82BB2B002D68AF /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6B5138471EBD23C200C992A8 /* bracket_example.py in Resources */ = {isa = PBXBuildFile; fileRef = 6B5138441EBD23C200C992A8 /* bracket_example.py */; };
 		6B5138481EBD23C200C992A8 /* shouty.py in Resources */ = {isa = PBXBuildFile; fileRef = 6B5138451EBD23C200C992A8 /* shouty.py */; };
 		6B5138491EBD23C200C992A8 /* spellcheck.py in Resources */ = {isa = PBXBuildFile; fileRef = 6B5138461EBD23C200C992A8 /* spellcheck.py */; };
+		6B9B4BA51EC012B2006C090B /* xi_plugin in Resources */ = {isa = PBXBuildFile; fileRef = 6B9B4BA41EC012B2006C090B /* xi_plugin */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* xi-syntect-plugin in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -60,6 +61,7 @@
 		6B5138441EBD23C200C992A8 /* bracket_example.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = bracket_example.py; path = "xi-editor/python/bracket_example.py"; sourceTree = SOURCE_ROOT; };
 		6B5138451EBD23C200C992A8 /* shouty.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = shouty.py; path = "xi-editor/python/shouty.py"; sourceTree = SOURCE_ROOT; };
 		6B5138461EBD23C200C992A8 /* spellcheck.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = spellcheck.py; path = "xi-editor/python/spellcheck.py"; sourceTree = SOURCE_ROOT; };
+		6B9B4BA41EC012B2006C090B /* xi_plugin */ = {isa = PBXFileReference; lastKnownFileType = folder; name = xi_plugin; path = "xi-editor/python/xi_plugin"; sourceTree = SOURCE_ROOT; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* xi-syntect-plugin */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "xi-syntect-plugin"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -177,6 +179,7 @@
 				6B5138441EBD23C200C992A8 /* bracket_example.py */,
 				6B5138451EBD23C200C992A8 /* shouty.py */,
 				6B5138461EBD23C200C992A8 /* spellcheck.py */,
+				6B9B4BA41EC012B2006C090B /* xi_plugin */,
 			);
 			name = xicore;
 			sourceTree = "<group>";
@@ -310,6 +313,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B9B4BA51EC012B2006C090B /* xi_plugin in Resources */,
 				6B5138491EBD23C200C992A8 /* spellcheck.py in Resources */,
 				F53EA2AD1DCAA8110071ACFD /* Main.storyboard in Resources */,
 				AE228F5D1C897CE7000E9B0F /* xi-core in Resources */,

--- a/XiEditor/Dispatcher.swift
+++ b/XiEditor/Dispatcher.swift
@@ -85,7 +85,7 @@ typealias ViewIdentifier = String
 
 enum Events { // namespace
     struct NewView: Event {
-        typealias Output = String
+        typealias Output = [String: AnyObject?]
         
         let path: String?
         let method = "new_view"
@@ -114,6 +114,18 @@ enum Events { // namespace
         
         let method = "save"
         var params: AnyObject? { return ["view_id": viewIdentifier, "file_path": path] as AnyObject }
+        let dispatchMethod = EventDispatchMethod.async
+    }
+
+    struct RunPlugin: Event {
+        typealias Output = Void
+        let viewIdentifier: ViewIdentifier
+        let plugin: String
+
+        let method = "plugin"
+        var params: AnyObject? {
+            return ["command": "start", "view_id": viewIdentifier, "plugin_name": plugin] as AnyObject
+        }
         let dispatchMethod = EventDispatchMethod.async
     }
 }

--- a/XiEditor/Dispatcher.swift
+++ b/XiEditor/Dispatcher.swift
@@ -85,7 +85,7 @@ typealias ViewIdentifier = String
 
 enum Events { // namespace
     struct NewView: Event {
-        typealias Output = [String: AnyObject?]
+        typealias Output = String
         
         let path: String?
         let method = "new_view"
@@ -127,5 +127,16 @@ enum Events { // namespace
             return ["command": "start", "view_id": viewIdentifier, "plugin_name": plugin] as AnyObject
         }
         let dispatchMethod = EventDispatchMethod.async
+    }
+    
+    struct InitialPlugins: Event {
+        typealias Output = [String]
+        let viewIdentifier: ViewIdentifier
+        
+        let method = "plugin"
+        var params: AnyObject? {
+            return ["command": "initial_plugins", "view_id": viewIdentifier] as AnyObject
+        }
+        let dispatchMethod = EventDispatchMethod.sync
     }
 }

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -66,9 +66,10 @@ class Document: NSDocument {
     convenience init(type: String) throws {
         self.init()
         self.fileType = type
-        Events.NewView(path: nil).dispatchWithCallback(dispatcher!) { (coreViewIdentifier) in
+        Events.NewView(path: nil).dispatchWithCallback(dispatcher!) { (response) in
             DispatchQueue.main.async {
-                self.coreViewIdentifier = coreViewIdentifier
+                self.coreViewIdentifier = (response["view_id"] as! String)
+                self.editViewController!.availablePlugins = response["available_plugins"] as! [String]
             }
         }
     }
@@ -78,9 +79,10 @@ class Document: NSDocument {
         self.init()
         self.fileURL = url
         self.fileType = typeName
-        Events.NewView(path: url.path).dispatchWithCallback(dispatcher!) { (coreViewIdentifier) in
+        Events.NewView(path: url.path).dispatchWithCallback(dispatcher!) { (response) in
             DispatchQueue.main.async {
-                self.coreViewIdentifier = coreViewIdentifier
+                self.coreViewIdentifier = (response["view_id"] as! String)
+                self.editViewController!.availablePlugins = response["available_plugins"] as! [String]
             }
         }
         try self.read(from: url, ofType: typeName)

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -40,7 +40,17 @@ class Document: NSDocument {
     /// coreViewIdentifier is the name used to identify this document when communicating with the Core.
     var coreViewIdentifier: ViewIdentifier? {
         didSet {
-            guard coreViewIdentifier != nil else { return }
+            guard let identifier = coreViewIdentifier else { return }
+            // on first set, request initial plugins
+            if oldValue == nil {
+                let req = Events.InitialPlugins(viewIdentifier: identifier)
+                dispatcher.coreConnection.sendRpcAsync(
+                req.method, params: req.params!) { [unowned self] (response) in
+                    DispatchQueue.main.async {
+                        self.editViewController!.availablePlugins = response as! [String]
+                    }
+                }
+            }
             // apply initial updates when coreViewIdentifier is set
             for pending in self.pendingNotifications {
                 self.sendRpcAsync(pending.method, params: pending.params)
@@ -68,8 +78,7 @@ class Document: NSDocument {
         self.fileType = type
         Events.NewView(path: nil).dispatchWithCallback(dispatcher!) { (response) in
             DispatchQueue.main.async {
-                self.coreViewIdentifier = (response["view_id"] as! String)
-                self.editViewController!.availablePlugins = response["available_plugins"] as! [String]
+                self.coreViewIdentifier = response
             }
         }
     }
@@ -81,8 +90,7 @@ class Document: NSDocument {
         self.fileType = typeName
         Events.NewView(path: url.path).dispatchWithCallback(dispatcher!) { (response) in
             DispatchQueue.main.async {
-                self.coreViewIdentifier = (response["view_id"] as! String)
-                self.editViewController!.availablePlugins = response["available_plugins"] as! [String]
+                self.coreViewIdentifier = response
             }
         }
         try self.read(from: url, ofType: typeName)

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -764,11 +764,15 @@
                                                 <action selector="debugTestFGSpans:" target="7er-QZ-amI" id="10b-2a-k0u"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Run Plugin" keyEquivalent="" id="dg6-hx-Gte">
+                                        <menuItem title="Plugin" id="eL2-QX-h3r">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="debugRunPlugin:" target="7er-QZ-amI" id="ehi-9m-zMB"/>
-                                            </connections>
+                                            <menu key="submenu" title="Plugin" id="23S-iW-lhp">
+                                                <items>
+                                                    <menuItem title="Item" id="iXd-lN-XfJ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
                                         </menuItem>
                                         <menuItem title="Goto Line" keyEquivalent="g" id="5bM-PX-gWE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES"/>


### PR DESCRIPTION
This branch adds support for the multi-plugin stuff in https://github.com/google/xi-editor/pull/255.

Plugins are listed in a dropdown in the Debug menu:

![screen shot 2017-05-07 at 1 24 56 pm](https://cloud.githubusercontent.com/assets/3330916/25783335/bea0cd70-3328-11e7-9ae4-ea17b209ade7.png)

And running multiple plugins is now fairly easy (here is syntect + the very simple bracket closing sample plugin)

![multi_plug](https://cloud.githubusercontent.com/assets/3330916/25783382/8977bbb2-3329-11e7-96f4-33538dd0f215.gif)

**note**: to run the python plugins, you will need to install the plugin lib: from `xi-editor/python/xi_plugins` run `pip3 install .`.

**also**: you may run into problems with Xcode resetting environment variables. To set environment variables in Xcode, option-click on the Run button to open the scheme editor, and set variables there:

![screen shot 2017-05-07 at 1 33 25 pm](https://cloud.githubusercontent.com/assets/3330916/25783423/f451862a-3329-11e7-8207-d5064dada714.png)





