### PR TITLE
Scroll past end of file

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -147,7 +147,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate {
         }
         shadowView?.updateScroll(scrollView.contentView.bounds, scrollView.documentView!.bounds)
         // if the window is resized, update the editViewHeight so we don't show scrollers unnecessarily
-        self.editViewHeight.constant = max(CGFloat(lines.height) * textMetrics.linespace + 2 * textMetrics.descent, scrollView.bounds.height)
+        updateEditViewHeight()
     }
     
     // MARK: - Core Commands
@@ -160,10 +160,16 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate {
 
         lines.applyUpdate(update: content)
         self.lineCount = lines.height
-        self.editViewHeight.constant = max(CGFloat(lines.height) * textMetrics.linespace + 2 * textMetrics.descent, scrollView.bounds.height)
+        updateEditViewHeight()
         editView.showBlinkingCursor = editView.isFrontmostView
         editView.needsDisplay = true
         gutterView.needsDisplay = true
+    }
+
+    fileprivate func updateEditViewHeight() {
+        let contentHeight = CGFloat(lines.height) * textMetrics.linespace + 2 * textMetrics.descent
+        let pastEndHeight = min(contentHeight, scrollView.bounds.height) - textMetrics.linespace - 2 * textMetrics.descent
+        self.editViewHeight.constant = max(contentHeight, scrollView.bounds.height) + pastEndHeight
     }
 
     func scrollTo(_ line: Int, _ col: Int) {

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -91,6 +91,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate {
     var firstLine: Int = 0
     var lastLine: Int = 0
 
+    // TODO: should be an option in the user preferences
+    var scrollPastEnd = false
+
     private var lastDragPosition: BufferPosition?
     /// handles autoscrolling when a drag gesture exists the window
     private var dragTimer: Timer?
@@ -168,8 +171,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate {
 
     fileprivate func updateEditViewHeight() {
         let contentHeight = CGFloat(lines.height) * textMetrics.linespace + 2 * textMetrics.descent
-        let pastEndHeight = min(contentHeight, scrollView.bounds.height) - textMetrics.linespace - 2 * textMetrics.descent
-        self.editViewHeight.constant = max(contentHeight, scrollView.bounds.height) + pastEndHeight
+        self.editViewHeight.constant = max(contentHeight, scrollView.bounds.height)
+        if scrollPastEnd {
+            self.editViewHeight.constant += min(contentHeight, scrollView.bounds.height)
+                - textMetrics.linespace - 2 * textMetrics.descent;
+        }
     }
 
     func scrollTo(_ line: Int, _ col: Int) {


### PR DESCRIPTION
Allow scrolling past the of a file. The behaviour is like Sublime's, where you can scroll down until on remaining line is still visible.

I am not sure if this is something that should be enabled by default, if not, I am fine with closing this and wait until with have user preferences.