### PR TITLE
Build failed because `String does not conform to AnyObject`

### DIFF
--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -208,7 +208,7 @@ class Document: NSDocument {
                       "rpc": [
                         "rpc_type": "notification",
                         "method": method,
-                        "params": innerParams]] as [String: AnyObject]
+                        "params": innerParams]] as [String: Any]
 
         dispatcher.coreConnection.sendRpcAsync("plugin", params: params)
     }


### PR DESCRIPTION
I tried to build this repo and got an error:

    xi-mac/XiEditor/Document.swift:216:34: error: value of type 'String' does not conform to expected dictionary value type 'AnyObject'

I fixed the error by changing `AnyObject` to `Any` on line 222

Now the build passes!

Note: I am using Swift version 3.0.2 (swiftlang-800.0.63 clang-800.0.42.1)

P.S. This is my first PR so if I am making any etiquette mistakes please let me know!