### PR TITLE
Support for new config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Screenshot (will need to be updated as syntax coloring and UI polish is added):
 ![xi screenshot](/doc/img/xi-mac-screenshot.png?raw=true)
 
 ## Getting started
-You need [Xcode 9.x](https://developer.apple.com/xcode/) (only on Mac) and [Rust](https://www.rust-lang.org/) (version 1.20  or higher.)
-You should have `cargo` in your path. You'll also need
-cmake installed, to run the syntax highlighter. If you have homebrew,
-easiest to run `brew install cmake`. It is possible to build without cmake,
-but requires some editing of build scripts.
+
+### Requirements
+- [Xcode 9.x](https://developer.apple.com/xcode/)
+- [Rust](https://www.rust-lang.org/). We test against the latest stable version,
+and recommend installing through [rustup](https:://rustup.rs).
+- `cmake`. We recommend installing through homebrew, with `brew install cmake`.
+
 
 Note: the front-end and back-end are now split into two separate repositories. This
 is the front-end, and the back-end (or core) is now in:
@@ -50,12 +52,28 @@ as a subdirectory.
 
 Or `open XiEditor.xcodeproj` and hit the Run button.
 
-It will look better if you have
-[InconsolataGo](http://levien.com/type/myfonts/inconsolata.html) installed, a
-customized version of Inconsolata tuned for code editing. You can change fonts
-per window in the Font menu or with `Cmd-Shift-T`. To choose another default font,
-edit the `CTFontCreateWithName()` call in EditView.swift.
+### Troubleshooting
 
+The most common cause of a failed build is an outdated version of `rustc`.
+If you've installed with rustup, make sure Rust is up to date by running
+`rustup update stable`.
+
+
+## Configuration
+
+User settings are currently stored in files; the general preferences are
+located at `~/Library/Application Support/XiEditor/preferences.xiconfig`.
+This file can be opened from File > Preferences (⌘ + ,).
+
+Users are encouraged to try out
+[Inconsolata](http://levien.com/type/myfonts/inconsolata.html), with which
+Xi is principally tested.
+
+### Theme
+
+A few theme files are bundled with the application. A theme can be selected
+from the Debug > Theme menu. There is not yet a mechanism for including
+custom themes.
 
 
 ## Authors

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
 		6B0DCDD41E8196D0007C14A3 /* GutterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD31E8196D0007C14A3 /* GutterView.swift */; };
 		6B0DCDD61E832101007C14A3 /* EditContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD51E832101007C14A3 /* EditContainerView.swift */; };
-		6B1D39101FC53F5C008CCA35 /* defaults.toml in Resources */ = {isa = PBXBuildFile; fileRef = 6B1D390F1FC53F5C008CCA35 /* defaults.toml */; };
+		6B1D39101FC53F5C008CCA35 /* client_example.toml in Resources */ = {isa = PBXBuildFile; fileRef = 6B1D390F1FC53F5C008CCA35 /* client_example.toml */; };
 		6B53F5F21EF963EB00A4C664 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B53F5F11EF963EB00A4C664 /* Theme.swift */; };
 		6B90DD1C1F129C1A00DF3CE2 /* PluginCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B90DD1B1F129C1A00DF3CE2 /* PluginCommand.swift */; };
 		6B90DD221F14110B00DF3CE2 /* UserInputPromptController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */; };
@@ -60,7 +60,7 @@
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		6B0DCDD31E8196D0007C14A3 /* GutterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutterView.swift; sourceTree = "<group>"; };
 		6B0DCDD51E832101007C14A3 /* EditContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditContainerView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		6B1D390F1FC53F5C008CCA35 /* defaults.toml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = defaults.toml; path = "xi-editor/rust/core-lib/assets/defaults.toml"; sourceTree = "<group>"; };
+		6B1D390F1FC53F5C008CCA35 /* client_example.toml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = client_example.toml; path = "xi-editor/rust/core-lib/assets/client_example.toml"; sourceTree = "<group>"; };
 		6B53F5F11EF963EB00A4C664 /* Theme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		6B90DD1B1F129C1A00DF3CE2 /* PluginCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginCommand.swift; sourceTree = "<group>"; };
 		6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInputPromptController.swift; sourceTree = "<group>"; };
@@ -179,7 +179,7 @@
 		D023DA021CD071B40087EC0A /* xicore */ = {
 			isa = PBXGroup;
 			children = (
-				6B1D390F1FC53F5C008CCA35 /* defaults.toml */,
+				6B1D390F1FC53F5C008CCA35 /* client_example.toml */,
 				AE041B971D4323460069AB8B /* build-rust-xcode.sh */,
 				AE228F5C1C897CE7000E9B0F /* xi-core */,
 				AE041BA51D4327EB0069AB8B /* plugins */,
@@ -318,7 +318,7 @@
 			files = (
 				F53EA2AD1DCAA8110071ACFD /* Main.storyboard in Resources */,
 				AE228F5D1C897CE7000E9B0F /* xi-core in Resources */,
-				6B1D39101FC53F5C008CCA35 /* defaults.toml in Resources */,
+				6B1D39101FC53F5C008CCA35 /* client_example.toml in Resources */,
 				AE041BA61D4327EB0069AB8B /* plugins in Resources */,
 				AE499DD21C82BB2B002D68AF /* Assets.xcassets in Resources */,
 			);

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50370A2A1D4209F300EA1B18 /* Dispatcher.swift */; };
 		6B0DCDD41E8196D0007C14A3 /* GutterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD31E8196D0007C14A3 /* GutterView.swift */; };
 		6B0DCDD61E832101007C14A3 /* EditContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0DCDD51E832101007C14A3 /* EditContainerView.swift */; };
+		6B1D39101FC53F5C008CCA35 /* defaults.toml in Resources */ = {isa = PBXBuildFile; fileRef = 6B1D390F1FC53F5C008CCA35 /* defaults.toml */; };
 		6B53F5F21EF963EB00A4C664 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B53F5F11EF963EB00A4C664 /* Theme.swift */; };
 		6B90DD1C1F129C1A00DF3CE2 /* PluginCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B90DD1B1F129C1A00DF3CE2 /* PluginCommand.swift */; };
 		6B90DD221F14110B00DF3CE2 /* UserInputPromptController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */; };
@@ -59,6 +60,7 @@
 		50370A2A1D4209F300EA1B18 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		6B0DCDD31E8196D0007C14A3 /* GutterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutterView.swift; sourceTree = "<group>"; };
 		6B0DCDD51E832101007C14A3 /* EditContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditContainerView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		6B1D390F1FC53F5C008CCA35 /* defaults.toml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = defaults.toml; path = "xi-editor/rust/core-lib/assets/defaults.toml"; sourceTree = "<group>"; };
 		6B53F5F11EF963EB00A4C664 /* Theme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		6B90DD1B1F129C1A00DF3CE2 /* PluginCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginCommand.swift; sourceTree = "<group>"; };
 		6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInputPromptController.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 		D023DA021CD071B40087EC0A /* xicore */ = {
 			isa = PBXGroup;
 			children = (
+				6B1D390F1FC53F5C008CCA35 /* defaults.toml */,
 				AE041B971D4323460069AB8B /* build-rust-xcode.sh */,
 				AE228F5C1C897CE7000E9B0F /* xi-core */,
 				AE041BA51D4327EB0069AB8B /* plugins */,
@@ -315,6 +318,7 @@
 			files = (
 				F53EA2AD1DCAA8110071ACFD /* Main.storyboard in Resources */,
 				AE228F5D1C897CE7000E9B0F /* xi-core in Resources */,
+				6B1D39101FC53F5C008CCA35 /* defaults.toml in Resources */,
 				AE041BA61D4327EB0069AB8B /* plugins in Resources */,
 				AE499DD21C82BB2B002D68AF /* Assets.xcassets in Resources */,
 			);

--- a/XiEditor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/XiEditor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:XiEditor.xcodeproj">
+      location = "group:../xi-editor/rust/core-lib/assets/defaults.toml">
+   </FileRef>
+   <FileRef
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -23,12 +23,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var dispatcher: Dispatcher?
 
-    //TODO: preferred font should be a user preference
-    let defaultFont = CTFontCreateWithName(("InconsolataGo" as CFString?)!, 14, nil)
+    // This is set to 'InconsolataGo' in the user preferences; this value is a fallback.
+    let fallbackFont = CTFontCreateWithName(("Menlo" as CFString?)!, 14, nil)
 
-    lazy var textMetrics: TextDrawingMetrics = TextDrawingMetrics(font: self.defaultFont,
+    lazy var textMetrics: TextDrawingMetrics = TextDrawingMetrics(font: self.fallbackFont,
                                                                   textColor: self.theme.foreground)
-    lazy var styleMap: StyleMap = StyleMap(font: self.defaultFont)
+    lazy var styleMap: StyleMap = StyleMap(font: self.fallbackFont)
 
     lazy var defaultConfigDirectory: URL = {
         let applicationDirectory = FileManager.default.urls(
@@ -46,7 +46,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                                         withIntermediateDirectories: true,
                                                         attributes: nil)
                 let preferencesPath = applicationDirectory.appendingPathComponent(PREFERENCES_FILE_NAME)
-                let defaultConfigPath = Bundle.main.url(forResource: "defaults", withExtension: "toml")
+                let defaultConfigPath = Bundle.main.url(forResource: "client_example", withExtension: "toml")
                 try FileManager.default.copyItem(at: defaultConfigPath!, to: preferencesPath)
 
 
@@ -218,7 +218,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func handleFontChange(fontName: String?, fontSize: CGFloat?) {
-        guard textMetrics.font.fontName != fontName && textMetrics.font.pointSize != fontSize else { return }
+        guard textMetrics.font.fontName != fontName || textMetrics.font.pointSize != fontSize else { return }
 
         if let newFont = NSFont(name: fontName ?? textMetrics.font.fontName,
                                 size: fontSize ?? textMetrics.font.pointSize) {

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -217,6 +217,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return nil
     }
 
+    @IBAction func openPreferences(_ sender: NSMenuItem) {
+        let delegate = (NSApplication.shared.delegate as? AppDelegate)
+        if let preferencesPath = delegate?.defaultConfigDirectory.appendingPathComponent(PREFERENCES_FILE_NAME) {
+            NSDocumentController.shared.openDocument(
+                withContentsOf: preferencesPath,
+                display: true,
+                completionHandler: { (document, alreadyOpen, error) in
+                    if let error = error {
+                        print("error opening preferences \(error)")
+                    }
+            });
+        }
+    }
+
     func handleFontChange(fontName: String?, fontSize: CGFloat?) {
         guard textMetrics.font.fontName != fontName || textMetrics.font.pointSize != fontSize else { return }
 

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -330,25 +330,21 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate {
         document.sendRpcAsync("debug_print_spans", params: [])
     }
     @IBAction func debugOverrideWhitespace(_ sender: NSMenuItem) {
+        var changes = [String: Any]()
         switch sender.title {
         case "Tabs":
-            let params = ["view_id": self.document.coreViewIdentifier!,
-                        "key": "translate_tabs_to_spaces",
-                        "value": false] as [String : Any]
-            document.dispatcher.coreConnection.sendRpcAsync("debug_override_setting", params: params)
+            changes["translate_tabs_to_spaces"] = false
         case let other where other.starts(with: "Spaces"):
-            let params = ["view_id": self.document.coreViewIdentifier!,
-                          "key": "translate_tabs_to_spaces",
-                          "value": true] as [String : Any]
-            let params2 = ["view_id": self.document.coreViewIdentifier!,
-                          "key": "tab_size",
-                          "value": sender.tag] as [String : Any]
-            document.dispatcher.coreConnection.sendRpcAsync("debug_override_setting", params: params)
-            document.dispatcher.coreConnection.sendRpcAsync("debug_override_setting", params: params2)
+            changes["translate_tabs_to_spaces"] = true
+            changes["tab_size"] = sender.tag
         default:
             fatalError("unexpected sender")
         }
+        let domain: [String: Any] = ["user_override": self.document.coreViewIdentifier!]
+        let params = ["domain": domain, "changes": changes]
+        document.dispatcher.coreConnection.sendRpcAsync("modify_user_config", params: params)
     }
+
     @objc func togglePlugin(_ sender: NSMenuItem) {
         switch sender.state {
         case NSControl.StateValue.off: Events.StartPlugin(
@@ -500,6 +496,21 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate {
 
     @IBAction func addNextLineToSelection(_ sender: NSMenuItem) {
         document.sendRpcAsync("add_selection_below", params: [])
+    }
+
+    @IBAction func openPreferences(_ sender: NSMenuItem) {
+        let delegate = (NSApplication.shared.delegate as? AppDelegate)
+        if let preferencesPath = delegate?.defaultConfigDirectory.appendingPathComponent(PREFERENCES_FILE_NAME) {
+            NSDocumentController.shared.openDocument(
+                withContentsOf: preferencesPath,
+                display: true,
+                completionHandler: { (document, alreadyOpen, error) in
+                    if let error = error {
+                        print("error opening preferences \(error)")
+                    }
+            });
+        }
+
     }
 }
 

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -497,21 +497,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate {
     @IBAction func addNextLineToSelection(_ sender: NSMenuItem) {
         document.sendRpcAsync("add_selection_below", params: [])
     }
-
-    @IBAction func openPreferences(_ sender: NSMenuItem) {
-        let delegate = (NSApplication.shared.delegate as? AppDelegate)
-        if let preferencesPath = delegate?.defaultConfigDirectory.appendingPathComponent(PREFERENCES_FILE_NAME) {
-            NSDocumentController.shared.openDocument(
-                withContentsOf: preferencesPath,
-                display: true,
-                completionHandler: { (document, alreadyOpen, error) in
-                    if let error = error {
-                        print("error opening preferences \(error)")
-                    }
-            });
-        }
-
-    }
 }
 
 // we set this in Document.swift when we load a new window or tab.

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -318,7 +318,11 @@ Gw
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="OTw-iT-AXI"/>
-                                        <menuItem title="Preferences…" keyEquivalent="," id="EAv-yV-wz8"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="EAv-yV-wz8">
+                                            <connections>
+                                                <action selector="openPreferences:" target="7er-QZ-amI" id="dzf-4q-1J8"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="gsd-kb-HGJ"/>
                                         <menuItem title="Services" id="LDz-hM-BVt">
                                             <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
- use `modify_user_configs` for setting whitespace
- use `client_started` to specify config & plugin directories

this depends on https://github.com/google/xi-editor/pull/431 and https://github.com/google/xi-editor/pull/433

closes #78