### PR TITLE
Fix incorrect path check

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -39,7 +39,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // create application support directory and copy preferences
         // file on first run
-        if !FileManager.default.fileExists(atPath: applicationDirectory.absoluteString) {
+        if !FileManager.default.fileExists(atPath: applicationDirectory.path) {
             do {
 
                 try FileManager.default.createDirectory(at: applicationDirectory,
@@ -50,10 +50,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 try FileManager.default.copyItem(at: defaultConfigPath!, to: preferencesPath)
 
 
-            } catch {
-                fatalError("Failed to create application support directory")
+            } catch let err  {
+                fatalError("Failed to create application support directory \(applicationDirectory.path). \(err)")
             }
-        }
+        } 
         return applicationDirectory
     }()
 


### PR DESCRIPTION
An executable built via the instructions will (currently) fail to launch.

It is not clear to my why this wasn't failing when built through Xcode.. 😕 