### PR TITLE
Add support for cancel_operation command

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -418,6 +418,7 @@ class EditView: NSView, NSTextInputClient {
         "scrollToEndOfDocument:": "move_to_end_of_document",
         "transpose:": "transpose",
         "yank:": "yank",
+        "cancelOperation:": "cancel_operation",
     ]
 
     override func doCommand(by aSelector: Selector) {

--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -111,8 +111,7 @@ extension EditViewController {
                      caseSensitive: !findViewController.ignoreCase)
             }
         }
-
-        findViewController.searchField.becomeFirstResponder()
+        editView.window?.makeFirstResponder(findViewController.searchField)
     }
 
     func closeFind() {
@@ -125,6 +124,8 @@ extension EditViewController {
         }
 
         editView.window?.makeFirstResponder(editView)
+        // forward command to editView to collapse find highlights?
+        editView.doCommand(by: #selector(NSResponder.cancelOperation(_:)))
     }
 
     fileprivate func updateShadowPosition(offset: CGFloat) {


### PR DESCRIPTION
This is client support for https://github.com/google/xi-editor/pull/443/

I've made the decision here that when the find panel is showing, <kbd>esc</kbd> will collapse the window _and_ send the `"cancel_operation"` RPC to xi-core; the alternative would be to collapse the window but leave the find results highlighted.

It is not totally clear to me that my decision is correct.