### PR TITLE
Fix two small issues from #89

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -144,8 +144,10 @@ class EditView: NSView, NSTextInputClient {
 
         let topPad = dataSource.textMetrics.linespace - dataSource.textMetrics.ascent
         let first = max(0, Int((floor(dirtyRect.origin.y - topPad) / dataSource.textMetrics.linespace)))
-        let last = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height - topPad) / dataSource.textMetrics.linespace))
+        let lastVisible = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height - topPad) / dataSource.textMetrics.linespace))
 
+        let totalLines = dataSource.lines.height
+        let last = min(totalLines, lastVisible)
         let lines = dataSource.lines.blockingGet(lines: first..<last)
 
         let missing = lines.enumerated().filter( { $0.element == nil } )

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -268,8 +268,8 @@ class LineCache {
                 print("semaphore timeout \(elapsed / 1000)us")
             } else {
                 print("finished waiting: \(elapsed / 1000)us")
+                waitingForLines.signal()
             }
-            waitingForLines.signal()
         }
 
         return queue.sync { state.linesForRange(range: lineRange) }


### PR DESCRIPTION
- Fix an issue where the signal would still fire when the semaphore wait failed;
- Fix an issue where we would wait on lines that didn't exist, timing out every time.