### PR TITLE
Fix font matching for italic font

### DIFF
--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -192,9 +192,12 @@ func closestMatch(of font: NSFont, traits: NSFontTraitMask, weight: Int) -> NSFo
     var weight = weight
     let fromWeight = fm.weight(of: font)
     let direction = fromWeight > weight ? 1 : -1
-    while weight != fromWeight {
+    while true {
         if let f = fm.font(withFamily: font.familyName ?? font.fontName, traits: traits, weight: weight, size: font.pointSize) {
             return f
+        }
+        if weight == fromWeight || weight + direction == fromWeight {
+            break
         }
         weight += direction
     }


### PR DESCRIPTION
The font matching code failed to find an italic font of the same
weight as the base font (though it would work when changing both the
italic flag and the weight).