### PR TITLE
Send scroll_to RPC when reusing view

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -55,7 +55,14 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         return controller
     }()
     
-    var document: Document!
+    var document: Document! {
+        didSet {
+            if oldValue != nil {
+                self.visibleLines = 0..<0
+                self.redrawEverything()
+            }
+        }
+    }
     
     var lines: LineCache = LineCache()
 


### PR DESCRIPTION
This fixes at least part of #79; if we were reusing a view (as when
opening a file if the frontmost view was empty) we weren't properly
sending the scroll_to notification.