### PR TITLE
Store TextLine objects in line cache

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -404,7 +404,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
     }
 
     func getLine(_ lineNum: Int) -> Line<LineAssoc>? {
-        return dataSource.lines.get(lineNum)
+        return dataSource.lines.locked().get(lineNum)
     }
 
     func partialInvalidate(invalid: InvalSet) {

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -403,7 +403,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         return Substring(s.utf16.prefix(ix)).utf8.count
     }
 
-    func getLine(_ lineNum: Int) -> Line? {
+    func getLine(_ lineNum: Int) -> Line<LineAssoc>? {
         return dataSource.lines.get(lineNum)
     }
 
@@ -427,10 +427,12 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         let yOff = topPad - scrollOrigin.y
         let first = max(0, Int((floor(dirtyRect.origin.y - topPad + scrollOrigin.y) / linespace)))
         let lastVisible = Int(ceil((dirtyRect.origin.y + dirtyRect.size.height - topPad + scrollOrigin.y) / linespace))
-        
-        let totalLines = dataSource.lines.height
+
+        // Note: this locks the line cache for the duration of the render
+        let lineCache = dataSource.lines.locked()
+        let totalLines = lineCache.height
         let last = min(totalLines, lastVisible)
-        let lines = dataSource.lines.blockingGet(lines: first..<last)
+        let lines = lineCache.blockingGet(lines: first..<last)
         let font = dataSource.textMetrics.font as CTFont
         let styleMap = dataSource.styleMap.locked()
         var textLines: [TextLine?] = []
@@ -448,11 +450,18 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 textLines.append(nil)
                 continue
             }
-            let builder = TextLineBuilder(line.text, font: font)
-            builder.setFgColor(argb: foregroundArgb)
-            styleMap.applyStyles(builder: builder, styles: line.styles)
-            let textLine = builder.build(fontCache: renderer.fontCache)
-            textLines.append(textLine)
+            let textLine: TextLine
+            if let assoc = lineCache.get(lineIx)?.assoc {
+                textLine = assoc.textLine
+                textLines.append(assoc.textLine)
+            } else {
+                let builder = TextLineBuilder(line.text, font: font)
+                builder.setFgColor(argb: foregroundArgb)
+                styleMap.applyStyles(builder: builder, styles: line.styles)
+                textLine = builder.build(fontCache: renderer.fontCache)
+                lineCache.setAssoc(lineIx, assoc: LineAssoc(textLine: textLine))
+                textLines.append(textLine)
+            }
             let y0 = yOff + linespace * CGFloat(lineIx)
             renderer.drawLineBg(line: textLine, x0: GLfloat(xOff), yRange: GLfloat(y0)..<GLfloat(y0 + linespace), selColor: selArgb)
         }
@@ -521,7 +530,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         renderer.drawSolidRect(x: 0, y: GLfloat(dirtyRect.origin.x), width: GLfloat(gutterWidth), height: GLfloat(dirtyRect.height), argb: colorToArgb(dataSource.theme.gutter))
         let gutterArgb = colorToArgb(dataSource.theme.gutterForeground)
         for lineIx in first..<last {
-            let hasCursor = dataSource.lines.get(lineIx)?.containsCursor ?? false
+            let hasCursor = lineCache.get(lineIx)?.containsCursor ?? false
             let gutterText = "\(lineIx + 1)"
             let builder = TextLineBuilder(gutterText, font: font)
             builder.setFgColor(argb: hasCursor ? foregroundArgb: gutterArgb)

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -444,6 +444,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         let selectionColor = self.isFrontmostView ? dataSource.theme.selection : dataSource.theme.inactiveSelection ?? dataSource.theme.selection
         let selArgb = colorToArgb(selectionColor)
         let foregroundArgb = colorToArgb(dataSource.theme.foreground)
+        let gutterArgb = colorToArgb(dataSource.theme.gutterForeground)
         for lineIx in first..<last {
             let relLineIx = lineIx - first
             guard let line = lines[relLineIx] else {
@@ -459,7 +460,14 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 builder.setFgColor(argb: foregroundArgb)
                 styleMap.applyStyles(builder: builder, styles: line.styles)
                 textLine = builder.build(fontCache: renderer.fontCache)
-                lineCache.setAssoc(lineIx, assoc: LineAssoc(textLine: textLine))
+
+                let gutterText = "\(lineIx + 1)"
+                let gBuilder = TextLineBuilder(gutterText, font: font)
+                gBuilder.setFgColor(argb: line.containsCursor ? foregroundArgb: gutterArgb)
+                let gutterTL = gBuilder.build(fontCache: renderer.fontCache)
+
+                let assoc = LineAssoc(textLine: textLine, gutterTL: gutterTL)
+                lineCache.setAssoc(lineIx, assoc: assoc)
                 textLines.append(textLine)
             }
             let y0 = yOff + linespace * CGFloat(lineIx)
@@ -528,16 +536,12 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         // is a bit of a hack, and some optimization might be possible with real clipping
         // (especially if the gutter background is the same as the theme background).
         renderer.drawSolidRect(x: 0, y: GLfloat(dirtyRect.origin.x), width: GLfloat(gutterWidth), height: GLfloat(dirtyRect.height), argb: colorToArgb(dataSource.theme.gutter))
-        let gutterArgb = colorToArgb(dataSource.theme.gutterForeground)
         for lineIx in first..<last {
-            let hasCursor = lineCache.get(lineIx)?.containsCursor ?? false
-            let gutterText = "\(lineIx + 1)"
-            let builder = TextLineBuilder(gutterText, font: font)
-            builder.setFgColor(argb: hasCursor ? foregroundArgb: gutterArgb)
-            let textLine = builder.build(fontCache: renderer.fontCache)
-            let x = gutterWidth - (gutterXPad + CGFloat(textLine.width))
-            let y0 = yOff + dataSource.textMetrics.ascent + linespace * CGFloat(lineIx)
-            renderer.drawLine(line: textLine, x0: GLfloat(x), y0: GLfloat(y0))
+            if let assoc = lineCache.get(lineIx)?.assoc {
+                let x = gutterWidth - (gutterXPad + CGFloat(assoc.gutterTL.width))
+                let y0 = yOff + dataSource.textMetrics.ascent + linespace * CGFloat(lineIx)
+                renderer.drawLine(line: assoc.gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
+            }
         }
     }
 }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -16,11 +16,16 @@ import Cocoa
 
 /// The EditViewDataSource protocol describes the properties that an editView uses to determine how to render its contents.
 protocol EditViewDataSource {
-    var lines: LineCache { get }
+    var lines: LineCache<LineAssoc> { get }
     var styleMap: StyleMap { get }
     var theme: Theme { get }
     var textMetrics: TextDrawingMetrics { get }
     var document: Document! { get }
+}
+
+/// Associated data stored per line in the line cache
+struct LineAssoc {
+    var textLine: TextLine
 }
 
 protocol FindDelegate {
@@ -62,7 +67,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         }
     }
     
-    var lines: LineCache = LineCache()
+    var lines = LineCache<LineAssoc>()
 
     var textMetrics: TextDrawingMetrics {
         return (NSApplication.shared.delegate as! AppDelegate).textMetrics

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -26,6 +26,7 @@ protocol EditViewDataSource {
 /// Associated data stored per line in the line cache
 struct LineAssoc {
     var textLine: TextLine
+    var gutterTL: TextLine
 }
 
 protocol FindDelegate {

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -162,6 +162,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     func redrawEverything() {
         updateGutterWidth()
         updateEditViewHeight()
+        lines.locked().flushAssoc()
         willScroll(to: scrollView.contentView.bounds.origin)
         editView.needsDisplay = true
     }

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -244,6 +244,7 @@ class LineCacheLocked<T> {
         return inner.cursorInval
     }
 
+    /// Returns the line for the given index, if it exists in the cache.
     func get(_ ix: Int) -> Line<T>? {
         return inner._get(ix)
     }
@@ -328,11 +329,6 @@ class LineCache<T> {
     /// Set of lines that need to be invalidated to blink the cursor
     var cursorInval: InvalSet {
         return locked().cursorInval
-    }
-
-    /// Returns the line for the given index, if it exists in the cache.
-    func get(_ ix: Int) -> Line<T>? {
-        return locked().get(ix)
     }
 
     /**

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -18,10 +18,12 @@ import Foundation
 typealias LineRange = CountableRange<Int>
 
 /// Represents a single line, including rendering information.
-struct Line {
+struct Line<T> {
     var text: String
     var cursor: [Int]
     var styles: [StyleSpan]
+    /// Associated data, to be managed by client
+    var assoc: T?
 
     /// A Boolean value representing whether this line contains selected/highlighted text.
     /// This is used to determine whether we should pre-draw its background.
@@ -59,14 +61,14 @@ struct Line {
 }
 
 /// The underlying state of the cache, with methods for applying update deltas.
-fileprivate class LineCacheState: UnfairLock {
+fileprivate class LineCacheState<T>: UnfairLock {
     /// A semaphore we use to wake up the main thread if it is blocking missing lines
     let waitingForLines = DispatchSemaphore(value: 0)
     /// Whether the main thread is waiting on the semaphore
     var isWaiting = false
 
     var nInvalidBefore = 0;
-    var lines: [Line?] = []
+    var lines: [Line<T>?] = []
     var nInvalidAfter = 0;
 
     var height: Int {
@@ -77,7 +79,7 @@ fileprivate class LineCacheState: UnfairLock {
         return  lines.count == 0 || (lines.count == 1 && lines[0]?.text  == "")
     }
 
-    func _get(_ ix: Int) -> Line? {
+    func _get(_ ix: Int) -> Line<T>? {
         if ix < nInvalidBefore { return nil }
         let ix = ix - nInvalidBefore
         if ix < lines.count {
@@ -86,7 +88,14 @@ fileprivate class LineCacheState: UnfairLock {
         return nil
     }
 
-    func linesForRange(range: LineRange) -> [Line?] {
+    func setAssoc(_ ix: Int, _ assoc: T?) {
+        assert(ix >= nInvalidBefore)
+        let ix = ix - nInvalidBefore
+        assert(ix < lines.count)
+        lines[ix]!.assoc = assoc
+    }
+
+    func linesForRange(range: LineRange) -> [Line<T>?] {
         return range.map( { _get($0) } )
     }
 
@@ -97,7 +106,7 @@ fileprivate class LineCacheState: UnfairLock {
         guard let ops = update["ops"] else { return inval }
         let oldHeight = height
         var newInvalidBefore = 0
-        var newLines: [Line?] = []
+        var newLines: [Line<T>?] = []
         var newInvalidAfter = 0
         var oldIx = 0;
         for op in ops as! [[String: AnyObject]] {
@@ -203,11 +212,11 @@ fileprivate class LineCacheState: UnfairLock {
 /// it holds an associated mutex during its lifetime.
 /// - Note: This uses a pattern that is very similar to Rust's
 /// [MutexGuard](https://doc.rust-lang.org/std/sync/struct.MutexGuard.html).
-class LineCacheLocked {
-    private var inner: LineCacheState
+class LineCacheLocked<T> {
+    private var inner: LineCacheState<T>
     var shouldSignal = false
 
-    fileprivate init(_ mutex: LineCacheState) {
+    fileprivate init(_ mutex: LineCacheState<T>) {
         inner = mutex
         inner.lock()
     }
@@ -235,11 +244,16 @@ class LineCacheLocked {
         return inner.cursorInval
     }
 
-    func get(_ ix: Int) -> Line? {
+    func get(_ ix: Int) -> Line<T>? {
         return inner._get(ix)
     }
 
-    func blockingGet(lines lineRange: LineRange) -> [Line?] {
+    /// Sets the associated data for a line. The line _must_ be valid.
+    func setAssoc(_ ix: Int, assoc: T) {
+        inner.setAssoc(ix, assoc)
+    }
+
+    func blockingGet(lines lineRange: LineRange) -> [Line<T>?] {
         let lines = inner.linesForRange(range: lineRange)
         let missingLines = lineRange.enumerated()
             .filter( { lines.count > $0.offset && lines[$0.offset] == nil })
@@ -288,14 +302,14 @@ class LineCacheLocked {
  `blockingGet(lines:)` method, which will block for some maximum amount of time
  waiting for the lines to arrive from xi-core.
  */
-class LineCache {
+class LineCache<T> {
 
     /// The underlying cache state
-    private let state = LineCacheState()
+    private let state = LineCacheState<T>()
 
     /// Lock the mutex protecting the linecache state and return an object giving
     /// safe mutable access to that state.
-    func locked() -> LineCacheLocked {
+    func locked() -> LineCacheLocked<T> {
         return LineCacheLocked(state)
     }
     
@@ -317,7 +331,7 @@ class LineCache {
     }
 
     /// Returns the line for the given index, if it exists in the cache.
-    func get(_ ix: Int) -> Line? {
+    func get(_ ix: Int) -> Line<T>? {
         return locked().get(ix)
     }
 
@@ -328,7 +342,7 @@ class LineCache {
      will block the calling thread for a short time, to see if the missing lines are
      contained in the next received update.
      */
-    func blockingGet(lines lineRange: LineRange) -> [Line?] {
+    func blockingGet(lines lineRange: LineRange) -> [Line<T>?] {
         return locked().blockingGet(lines: lineRange)
     }
 

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -236,7 +236,7 @@ class LineCacheLocked<T> {
     }
 
     /// The maximum time (in milliseconds) to block when missing lines.
-    let MAX_BLOCK_MS = 15;
+    let MAX_BLOCK_MS = 30;
 
     var isEmpty: Bool {
         return inner.isEmpty

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -95,6 +95,12 @@ fileprivate class LineCacheState<T>: UnfairLock {
         lines[ix]!.assoc = assoc
     }
 
+    func flushAssoc() {
+        for ix in 0..<lines.count {
+            lines[ix]?.assoc = nil
+        }
+    }
+
     func linesForRange(range: LineRange) -> [Line<T>?] {
         return range.map( { _get($0) } )
     }
@@ -252,6 +258,11 @@ class LineCacheLocked<T> {
     /// Sets the associated data for a line. The line _must_ be valid.
     func setAssoc(_ ix: Int, assoc: T) {
         inner.setAssoc(ix, assoc)
+    }
+
+    /// Flushes all associated data, necessary on theme change.
+    func flushAssoc() {
+        inner.flushAssoc()
     }
 
     func blockingGet(lines lineRange: LineRange) -> [Line<T>?] {


### PR DESCRIPTION
This patch retains `TextLine` objects and stores them in the line cache, avoiding the need to rebuild them continually. With this change, we see consistent 120fps and pleasantly low CPU usage on scrolling. In addition, it should reduce the latency for operations such as inserting or deleting a line (most of the surrounding content is retained).

Note that the text for the line number in the gutter is also cached.

The associated data in the line cache is generic. This isn't strictly needed as there's only one instantiation, but perhaps helps highlight the separation of concerns. It's possible we'll use associated data for caret offsets (although that could also be moved into TextLine).