### PR TITLE
Generate simple tracing data

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AE499DEB1C82BB2B002D68AF /* XiEditorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE499DEA1C82BB2B002D68AF /* XiEditorUITests.swift */; };
 		AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE499DF81C82C835002D68AF /* CoreConnection.swift */; };
 		AEC4F6B31FF5AF130060E10E /* UnfairLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC4F6B21FF5AF130060E10E /* UnfairLock.swift */; };
+		AEC4F6CA1FFB02F10060E10E /* Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC4F6C91FFB02F10060E10E /* Trace.swift */; };
 		AED22D761FE836880096E7C3 /* TextPlane.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED22D751FE836880096E7C3 /* TextPlane.swift */; };
 		AED22D781FE8404D0096E7C3 /* Renderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED22D771FE8404D0096E7C3 /* Renderer.swift */; };
 		AED22D7A1FE8418A0096E7C3 /* Atlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED22D791FE8418A0096E7C3 /* Atlas.swift */; };
@@ -90,6 +91,7 @@
 		AE499DEC1C82BB2B002D68AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AE499DF81C82C835002D68AF /* CoreConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreConnection.swift; sourceTree = "<group>"; };
 		AEC4F6B21FF5AF130060E10E /* UnfairLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnfairLock.swift; sourceTree = "<group>"; };
+		AEC4F6C91FFB02F10060E10E /* Trace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trace.swift; sourceTree = "<group>"; };
 		AED22D751FE836880096E7C3 /* TextPlane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPlane.swift; sourceTree = "<group>"; };
 		AED22D771FE8404D0096E7C3 /* Renderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Renderer.swift; sourceTree = "<group>"; };
 		AED22D791FE8418A0096E7C3 /* Atlas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atlas.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 				AE168C5B1E4AD87B008249AE /* LineCache.swift */,
 				AE0243F51E4BDF8A00641BDA /* StyleMap.swift */,
 				AEC4F6B21FF5AF130060E10E /* UnfairLock.swift */,
+				AEC4F6C91FFB02F10060E10E /* Trace.swift */,
 				6B90DD1B1F129C1A00DF3CE2 /* PluginCommand.swift */,
 				6B53F5F11EF963EB00A4C664 /* Theme.swift */,
 				6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */,
@@ -395,6 +398,7 @@
 				6B53F5F21EF963EB00A4C664 /* Theme.swift in Sources */,
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,
 				50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */,
+				AEC4F6CA1FFB02F10060E10E /* Trace.swift in Sources */,
 				AED23F181C83CBED002246CE /* EditView.swift in Sources */,
 				AE499DD01C82BB2B002D68AF /* AppDelegate.swift in Sources */,
 				AEC4F6B31FF5AF130060E10E /* UnfairLock.swift in Sources */,

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -123,7 +123,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         case "update":
             let update = json["update"] as! [String: AnyObject]
             let viewIdentifier = json["view_id"] as! String
+            globalTrace.trace("dfvi", .main, .begin)
             let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
+            globalTrace.trace("dfvi", .main, .end)
             if document == nil { print("document missing for view id \(viewIdentifier)") }
             document?.updateAsync(update: update)
         case "def_style":
@@ -294,5 +296,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         testWindow = NSWindow(contentRect: frame, styleMask: [.titled, .closable, .resizable, .miniaturizable], backing: .buffered, defer: false)
         testWindow?.makeKeyAndOrderFront(self)
         testWindow?.contentView = TextPlaneDemo(frame: frame)
+    }
+    
+    @IBAction func writeTrace(_ sender: AnyObject) {
+        globalTrace.write()
     }
 }

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -78,7 +78,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     }
 
     func applicationWillFinishLaunching(_ aNotification: Notification) {
-        globalTrace.trace("appWillLaunch", .main, .begin)
+        Trace.shared.trace("appWillLaunch", .main, .begin)
 
         guard let corePath = Bundle.main.path(forResource: "xi-core", ofType: ""),
         let bundledPluginPath = Bundle.main.path(forResource: "plugins", ofType: "")
@@ -100,7 +100,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         let preferredTheme = UserDefaults.standard.string(forKey: USER_DEFAULTS_THEME_KEY) ?? "InspiredGitHub"
         let req = Events.SetTheme(themeName: preferredTheme)
         dispatcher.coreConnection.sendRpcAsync(req.method, params: req.params!)
-        globalTrace.trace("appWillLaunch", .main, .end)
+        Trace.shared.trace("appWillLaunch", .main, .end)
         documentController = XiDocumentController()
     }
 
@@ -251,6 +251,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     }
 
     @IBAction func writeTrace(_ sender: AnyObject) {
-        globalTrace.write()
+        Trace.shared.write()
     }
 }

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -77,6 +77,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillFinishLaunching(_ aNotification: Notification) {
+        globalTrace.trace("appWillLaunch", .main, .begin)
 
         guard let corePath = Bundle.main.path(forResource: "xi-core", ofType: ""),
         let bundledPluginPath = Bundle.main.path(forResource: "plugins", ofType: "")
@@ -105,6 +106,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let preferredTheme = UserDefaults.standard.string(forKey: USER_DEFAULTS_THEME_KEY) ?? "InspiredGitHub"
         let req = Events.SetTheme(themeName: preferredTheme)
         dispatcher.coreConnection.sendRpcAsync(req.method, params: req.params!)
+        globalTrace.trace("appWillLaunch", .main, .end)
     }
 
     /// returns the NSDocument corresponding to the given viewIdentifier
@@ -297,7 +299,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         testWindow?.makeKeyAndOrderFront(self)
         testWindow?.contentView = TextPlaneDemo(frame: frame)
     }
-    
+
     @IBAction func writeTrace(_ sender: AnyObject) {
         globalTrace.write()
     }

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -127,14 +127,14 @@ class CoreConnection {
     }
 
     func handleRaw(_ data: Data) {
-        globalTrace.trace("handleRaw", .rpc, .begin)
+        Trace.shared.trace("handleRaw", .rpc, .begin)
         do {
             let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
             handleRpc(json)
         } catch {
             print("json error \(error.localizedDescription)")
         }
-        globalTrace.trace("handleRaw", .rpc, .end)
+        Trace.shared.trace("handleRaw", .rpc, .end)
     }
 
     /// handle a JSON RPC call. Determines whether it is a request, response or notification
@@ -230,7 +230,7 @@ class CoreConnection {
     /// send an RPC request, returning immediately. The callback will be called when the
     /// response comes in, likely from a different thread
     func sendRpcAsync(_ method: String, params: Any, callback: ((Any?) -> ())? = nil) {
-        globalTrace.trace("send \(method)", .rpc, .begin)
+        Trace.shared.trace("send \(method)", .rpc, .begin)
         var req = ["method": method, "params": params] as [String : Any]
         if let callback = callback {
             queue.sync {
@@ -241,7 +241,7 @@ class CoreConnection {
             }
         }
         sendJson(req as Any)
-        globalTrace.trace("send \(method)", .rpc, .end)
+        Trace.shared.trace("send \(method)", .rpc, .end)
     }
 
     /// send RPC synchronously, blocking until return. Note: there is no ordering guarantee on

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -200,23 +200,23 @@ class Document: NSDocument {
     /// Send a notification specific to the tab. If the tab name hasn't been set, then the
     /// notification is queued, and sent when the tab name arrives.
     func sendRpcAsync(_ method: String, params: Any, callback: ((Any?) -> ())? = nil) {
-        globalTrace.trace(method, .rpc, .begin)
+        Trace.shared.trace(method, .rpc, .begin)
         if let coreViewIdentifier = coreViewIdentifier {
             let inner = ["method": method, "params": params, "view_id": coreViewIdentifier] as [String : Any]
             dispatcher?.coreConnection.sendRpcAsync("edit", params: inner, callback: callback)
         } else {
             pendingNotifications.append(PendingNotification(method: method, params: params, callback: callback))
         }
-        globalTrace.trace(method, .rpc, .end)
+        Trace.shared.trace(method, .rpc, .end)
     }
 
     /// Note: this is a blocking call, and will also fail if the tab name hasn't been set yet.
     /// We should try to migrate users to either fully async or callback based approaches.
     func sendRpc(_ method: String, params: Any) -> Any? {
-        globalTrace.trace(method, .rpc, .begin)
+        Trace.shared.trace(method, .rpc, .begin)
         let inner = ["method": method as AnyObject, "params": params, "view_id": coreViewIdentifier as AnyObject] as [String : Any]
         let result = dispatcher?.coreConnection.sendRpc("edit", params: inner)
-        globalTrace.trace(method, .rpc, .end)
+        Trace.shared.trace(method, .rpc, .end)
         return result
     }
 

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -182,19 +182,24 @@ class Document: NSDocument {
     /// Send a notification specific to the tab. If the tab name hasn't been set, then the
     /// notification is queued, and sent when the tab name arrives.
     func sendRpcAsync(_ method: String, params: Any, callback: ((Any?) -> ())? = nil) {
+        globalTrace.trace(method, .rpc, .begin)
         if let coreViewIdentifier = coreViewIdentifier {
             let inner = ["method": method, "params": params, "view_id": coreViewIdentifier] as [String : Any]
             dispatcher?.coreConnection.sendRpcAsync("edit", params: inner, callback: callback)
         } else {
             pendingNotifications.append(PendingNotification(method: method, params: params, callback: callback))
         }
+        globalTrace.trace(method, .rpc, .end)
     }
 
     /// Note: this is a blocking call, and will also fail if the tab name hasn't been set yet.
     /// We should try to migrate users to either fully async or callback based approaches.
     func sendRpc(_ method: String, params: Any) -> Any? {
+        globalTrace.trace(method, .rpc, .begin)
         let inner = ["method": method as AnyObject, "params": params, "view_id": coreViewIdentifier as AnyObject] as [String : Any]
-        return dispatcher?.coreConnection.sendRpc("edit", params: inner)
+        let result = dispatcher?.coreConnection.sendRpc("edit", params: inner)
+        globalTrace.trace(method, .rpc, .end)
+        return result
     }
 
     /// Send a custom plugin command.

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -424,10 +424,10 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
 
     // Rendering using TextPlane
     func render(_ renderer: Renderer, dirtyRect: NSRect) {
-        globalTrace.trace("EditView render", .main, .begin)
+        Trace.shared.trace("EditView render", .main, .begin)
         renderer.clear(dataSource.theme.background)
         if dataSource.document.coreViewIdentifier == nil {
-            globalTrace.trace("EditView render", .main, .end)
+            Trace.shared.trace("EditView render", .main, .end)
             return
         }
         let linespace = dataSource.textMetrics.linespace
@@ -553,6 +553,6 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 renderer.drawLine(line: assoc.gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
             }
         }
-        globalTrace.trace("EditView render", .main, .end)
+        Trace.shared.trace("EditView render", .main, .end)
     }
 }

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -424,8 +424,12 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
 
     // Rendering using TextPlane
     func render(_ renderer: Renderer, dirtyRect: NSRect) {
+        globalTrace.trace("EditView render", .main, .begin)
         renderer.clear(dataSource.theme.background)
-        if dataSource.document.coreViewIdentifier == nil { return }
+        if dataSource.document.coreViewIdentifier == nil {
+            globalTrace.trace("EditView render", .main, .end)
+            return
+        }
         let linespace = dataSource.textMetrics.linespace
         let topPad = linespace - dataSource.textMetrics.ascent
         let xOff = gutterWidth + x0 - scrollOrigin.x
@@ -548,5 +552,6 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 renderer.drawLine(line: assoc.gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
             }
         }
+        globalTrace.trace("EditView render", .main, .end)
     }
 }

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -279,9 +279,9 @@ class LineCacheLocked<T> {
             let blockTime = mach_absolute_time()
             inner.isWaiting = true
             inner.unlock()
-            globalTrace.trace("blockingGet", .main, .begin)
+            Trace.shared.trace("blockingGet", .main, .begin)
             let waitResult = inner.waitingForLines.wait(timeout: .now() + .milliseconds(MAX_BLOCK_MS))
-            globalTrace.trace("blockingGet", .main, .end)
+            Trace.shared.trace("blockingGet", .main, .end)
             inner.lock()
 
             let elapsed = mach_absolute_time() - blockTime
@@ -303,9 +303,9 @@ class LineCacheLocked<T> {
     }
 
     func applyUpdate(update: [String: AnyObject]) -> InvalSet {
-        globalTrace.trace("applyUpdate", .main, .begin)
+        Trace.shared.trace("applyUpdate", .main, .begin)
         let inval = inner.applyUpdate(update: update)
-        globalTrace.trace("applyUpdate", .main, .end)
+        Trace.shared.trace("applyUpdate", .main, .end)
         if inner.isWaiting {
             shouldSignal = true
             inner.isWaiting = false

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -279,7 +279,9 @@ class LineCacheLocked<T> {
             let blockTime = mach_absolute_time()
             inner.isWaiting = true
             inner.unlock()
+            globalTrace.trace("blockingGet", .main, .begin)
             let waitResult = inner.waitingForLines.wait(timeout: .now() + .milliseconds(MAX_BLOCK_MS))
+            globalTrace.trace("blockingGet", .main, .end)
             inner.lock()
 
             let elapsed = mach_absolute_time() - blockTime
@@ -301,8 +303,10 @@ class LineCacheLocked<T> {
     }
 
     func applyUpdate(update: [String: AnyObject]) -> InvalSet {
+        globalTrace.trace("applyUpdate", .main, .begin)
         let inval = inner.applyUpdate(update: update)
-        if inner.isWaiting {
+        globalTrace.trace("applyUpdate", .main, .end)
+       if inner.isWaiting {
             shouldSignal = true
             inner.isWaiting = false
         }

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -306,7 +306,7 @@ class LineCacheLocked<T> {
         globalTrace.trace("applyUpdate", .main, .begin)
         let inval = inner.applyUpdate(update: update)
         globalTrace.trace("applyUpdate", .main, .end)
-       if inner.isWaiting {
+        if inner.isWaiting {
             shouldSignal = true
             inner.isWaiting = false
         }

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -863,6 +863,12 @@ Gw
                                                 <action selector="textPlaneTest:" target="7er-QZ-amI" id="JPq-cw-4Il"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Write Trace" keyEquivalent="" id="2Bz-a3-hNc">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="writeTrace:" target="7er-QZ-amI" id="rFd-ai-H9o"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>

--- a/XiEditor/Trace.swift
+++ b/XiEditor/Trace.swift
@@ -17,13 +17,15 @@
 
 import Foundation
 
-var globalTrace = Trace()
-
+/// Collect trace events so they can be output in Chrome tracing format.
 class Trace {
     let mutex = UnfairLock()
     let BUF_SIZE = 100_000
     var buf: [TraceEntry]
     var n_entries = 0
+
+    /// Shared instance, most uses should call this.
+    static var shared = Trace()
 
     init() {
         buf = [TraceEntry](repeating: TraceEntry(), count: BUF_SIZE)
@@ -45,7 +47,7 @@ class Trace {
     func write() {
         let pid = getpid()
         let path = "/tmp/xi-trace-\(pid)"
-        if !FileManager().createFile(atPath: path, contents: nil, attributes: nil) {
+        if !FileManager.default.createFile(atPath: path, contents: nil, attributes: nil) {
             print("error creating trace file")
             return
         }

--- a/XiEditor/Trace.swift
+++ b/XiEditor/Trace.swift
@@ -1,0 +1,96 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A simple mechanism for logging trace events and outputting a file in
+// Chrome tracing format
+
+import Foundation
+
+var globalTrace = Trace()
+
+class Trace {
+    let mutex = UnfairLock()
+    let BUF_SIZE = 100_000
+    var buf: [TraceEntry]
+    var n_entries = 0
+
+    init() {
+        buf = [TraceEntry](repeating: TraceEntry(), count: BUF_SIZE)
+    }
+
+    func trace(_ name: String, _ cat: TraceCategory, _ ph: TracePhase) {
+        mutex.lock()
+        let i = n_entries % BUF_SIZE
+        buf[i].name = name
+        buf[i].cat = cat
+        buf[i].ph = ph
+        buf[i].abstime = mach_absolute_time()
+        pthread_threadid_np(nil, &buf[i].tid)
+        n_entries += 1
+        mutex.unlock()
+    }
+
+    // TODO: more control over where this gets saved
+    func write() {
+        let pid = getpid()
+        let path = "/tmp/xi-trace-\(pid)"
+        if !FileManager().createFile(atPath: path, contents: nil, attributes: nil) {
+            print("error creating trace file")
+            return
+        }
+        guard let fh = FileHandle(forWritingAtPath: path) else {
+            print("error opening trace file for writing")
+            return
+        }
+        fh.write(Data("[\n".utf8))
+        for entry_num in max(0, n_entries - BUF_SIZE) ..< n_entries {
+            let i = entry_num % BUF_SIZE
+            let ts = buf[i].abstime / 1000
+            let comma = entry_num == n_entries - 1 ? "" : ","
+            fh.write(Data("""
+                  {"name": "\(buf[i].name)", "cat": "\(buf[i].cat)", "ph": "\(buf[i].ph.rawValue)", \
+                "pid": \(pid), "tid": \(buf[i].tid), "ts": \(ts)}\(comma)\n
+                """.utf8))
+        }
+        fh.write(Data("]\n".utf8))
+    }
+}
+
+enum TraceCategory: String {
+    case main
+    case rpc
+}
+
+enum TracePhase: String {
+    case begin = "B"
+    case end = "E"
+    case instant = "I"
+}
+
+struct TraceEntry {
+    var name: String
+    var cat: TraceCategory
+    var ph: TracePhase
+    var abstime: UInt64  // In mach_absolute_time format
+    var tid: UInt64
+
+    /// Create a default trace entry, contents don't matter as it's just preallocated
+    init() {
+        name = ""
+        cat = .main
+        ph = .instant
+        abstime = mach_absolute_time()
+        tid = 0
+    }
+}


### PR DESCRIPTION
Adds a "write trace" to the debug menu, which dumps a trace file in
Chrome trace (catapult) format to /tmp. Right now we trace the basics
of sending and receiving RPC's, as well as the render method in
EditView (this is basically the critical path for editing and
scrolling).