### PR TITLE
Improve new window placement

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -15,6 +15,7 @@
 import Cocoa
 
 let USER_DEFAULTS_THEME_KEY = "io.xi-editor.settings.theme"
+let USER_DEFAULTS_NEW_WINDOW_FRAME = "io.xi-editor.settings.preferredWindowFrame"
 let XI_CONFIG_DIR = "XI_CONFIG_DIR";
 let PREFERENCES_FILE_NAME = "preferences.xiconfig"
 

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -139,6 +139,17 @@ class Document: NSDocument {
         self.editViewController = windowController.contentViewController as? EditViewController
         editViewController?.document = self
         windowController.window?.delegate = editViewController
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(Document.windowChangedNotification(_:)),
+            name: NSWindow.didMoveNotification, object: nil)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(Document.windowChangedNotification(_:)),
+            name: NSWindow.didResizeNotification, object: nil)
+
         self.addWindowController(windowController)
     }
 
@@ -249,5 +260,13 @@ class Document: NSDocument {
         }
         Document._lastWindowFrame = nextFrame
         return nextFrame
+    }
+    
+    /// Updates the location used for creating new windows on launch
+    @objc func windowChangedNotification(_ notification: Notification) {
+        if let window = notification.object as? NSWindow {
+            let frameString = NSStringFromRect(window.frame)
+            UserDefaults.standard.setValue(frameString, forKey: USER_DEFAULTS_NEW_WINDOW_FRAME)
+        }
     }
 }

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -245,8 +245,8 @@ class Document: NSDocument {
     /// - Note: This attempts to replicate the behaviour of native macOS applications.
     /// On launch, an initial location is chosen, generally based on the position of
     /// the last manually moved view during the application's last run; subsequent
-    /// windows are offset from this by approximately thie width of the title bar.
-    /// If a window clips the screen, the position starts again from the beggining
+    /// windows are offset from this by approximately the width of the title bar.
+    /// If a window clips the screen, the position starts again from the beginning
     /// of the clipped axis.
     func frameForNewWindow() -> NSRect {
         let offsetSize: CGFloat = 22


### PR DESCRIPTION
This is a little improvement to how new windows are positioned:

1. For each application run, we keep track of the last new window position/size; new windows are positioned offset from this, so they cascade. They wrap to the top or side of the screen if their new position would clip.

2. When the user manually moves or positions a view at any point, we save the position of that view to be the 'new view position' on the next launch.

This was based on me copying the behaviour of Terminal.app. I'm not sure I find this behaviour fully satisfying, (I could imagine new windows being created offset from the current window, for instance) but I think it's a clear improvement over the current mess.