### PR TITLE
Suppress duplicate rendering

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -89,6 +89,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             needsDisplay = true
         }
     }
+    var lastRevisionRendered = 0
     var gutterXPad: CGFloat = 8
     var gutterWidth: CGFloat = 0
 
@@ -553,6 +554,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
                 renderer.drawLine(line: assoc.gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
             }
         }
+        lastRevisionRendered = lineCache.revision
         Trace.shared.trace("EditView render", .main, .end)
     }
 }


### PR DESCRIPTION
The `update` notification from the core always invalidated the lines
that changed, even when the update happened inside a blockingGetLines
request initiated by EditView.render. This patch keeps track of which
revision was rendered, and suppresses the invalidation if it's already
current.