### PR TITLE
Remove gutter from line cache

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -26,7 +26,6 @@ protocol EditViewDataSource {
 /// Associated data stored per line in the line cache
 struct LineAssoc {
     var textLine: TextLine
-    var gutterTL: TextLine
 }
 
 protocol FindDelegate {


### PR DESCRIPTION
The gutter invalidation logic is different from regular lines.  It
should only be invalidated when a newline is inserted & that newline
insertion invalidates all following lines.  This is in contrast to other
things using the line cache which only invalidate on line changes &
never newlines.  In fact, the gutter is invalidated whenever the cursor
changes lines too.

This fixes the bug where adding a newline in the middle of a document
has an off-by-1 error in the gutter line count.

Fixes #115 