### PR TITLE
Optimize gutter cache

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -160,6 +160,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         updateEditViewHeight()
         lines.locked().flushAssoc()
         willScroll(to: scrollView.contentView.bounds.origin)
+        editView.gutterCache = nil
         editView.needsDisplay = true
     }
 

--- a/XiEditor/XiTextPlane/TextLine.swift
+++ b/XiEditor/XiTextPlane/TextLine.swift
@@ -169,7 +169,7 @@ struct TextLine {
         return CTLineGetTypographicBounds(ctLine, nil, nil, nil)
     }
 
-    /// Fast approach to build a new string out of an atlast of glyphs.  This
+    /// Fast approach to build a new string out of an atlas of glyphs.  This
     /// only works properly (i.e. rendered correctly) for monospace fonts
     /// although non-monospace fonts will still produce some output.
     func scatterGather<C: Collection>(indices glyphIndices: C, font: CTFont)


### PR DESCRIPTION
Build the gutter digits for foreground & background.  Then use scatter-gather on the appropriate cached TextLine to quickly create a TextLine for the necessary line number.  This gets us back within range of the previous cached gutter performance with the same correctness as without the cache.

Fixes #115