### PR TITLE
Capture FPS statistics

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		6B90DD221F14110B00DF3CE2 /* UserInputPromptController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */; };
 		6BA1873B1FDDD7B6008220DA /* XiClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA1873A1FDDD7B6008220DA /* XiClipView.swift */; };
 		6BF9575B1FD70C420010BAE6 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF9575A1FD70C420010BAE6 /* Client.swift */; };
+		832910D920229C2D0042C32B /* Fps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832910D820229C2D0042C32B /* Fps.swift */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* plugins in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* plugins */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -78,6 +79,7 @@
 		6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInputPromptController.swift; sourceTree = "<group>"; };
 		6BA1873A1FDDD7B6008220DA /* XiClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiClipView.swift; sourceTree = "<group>"; };
 		6BF9575A1FD70C420010BAE6 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		832910D820229C2D0042C32B /* Fps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fps.swift; sourceTree = "<group>"; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* plugins */ = {isa = PBXFileReference; lastKnownFileType = text; path = plugins; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -182,6 +184,7 @@
 				F53EA2AC1DCAA8110071ACFD /* Main.storyboard */,
 				AE499DD11C82BB2B002D68AF /* Assets.xcassets */,
 				28F1ED491EC4C735008839BE /* Search.swift */,
+				832910D820229C2D0042C32B /* Fps.swift */,
 			);
 			path = XiEditor;
 			sourceTree = "<group>";
@@ -413,6 +416,7 @@
 				F5BDBF371DCA9D2C0042430B /* Document.swift in Sources */,
 				6038770720057B4500AABF17 /* XiDocumentController.swift in Sources */,
 				6B90DD221F14110B00DF3CE2 /* UserInputPromptController.swift in Sources */,
+				832910D920229C2D0042C32B /* Fps.swift in Sources */,
 				AED22D781FE8404D0096E7C3 /* Renderer.swift in Sources */,
 				6BA1873B1FDDD7B6008220DA /* XiClipView.swift in Sources */,
 				AED22D7A1FE8418A0096E7C3 /* Atlas.swift in Sources */,

--- a/XiEditor/Fps.swift
+++ b/XiEditor/Fps.swift
@@ -1,0 +1,179 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public struct FpsMeasurement {
+    fileprivate let start : DispatchTime
+    fileprivate let end : DispatchTime
+    
+    public init(from start: DispatchTime, to end: DispatchTime) {
+        self.start = start
+        self.end = end
+    }
+
+    public static func fps(nanosecondsPerFrame: UInt64) -> Double {
+        // seconds per frame = (nanoseconds per frame) / (nanoseconds per second)
+        //                   === (ns/frame) / (ns/s)
+        //                   === (ns/frame) * (s/ns)
+        //                   === s/frame
+        //
+        // frames per second = 1 / (seconds per frame)
+        //                   === 1 / (nanoseconds per frame / nanoseconds per second)
+        //                   === nanoseconds per second / nanoseconds per frame
+        //                   === (ns/s) / (ns/frame)
+        //                   === (ns/s) * (frame/ns)
+        return Double(NSEC_PER_SEC) / Double(nanosecondsPerFrame)
+    }
+
+    public func fps() -> Double {
+        return FpsMeasurement.fps(nanosecondsPerFrame: self.elapsedNanoseconds())
+    }
+
+    public func elapsedSeconds() -> Double {
+        return Double(self.elapsedNanoseconds()) / Double(NSEC_PER_SEC)
+    }
+
+    public func elapsedMilliseconds() -> Double {
+        return Double(self.elapsedNanoseconds()) / Double(NSEC_PER_MSEC)
+    }
+
+    public func elapsedNanoseconds() -> UInt64 {
+        return self.end.uptimeNanoseconds - self.start.uptimeNanoseconds
+    }
+
+    public func elapsedNanoseconds(since start: DispatchTime) -> UInt64 {
+        return end.uptimeNanoseconds - start.uptimeNanoseconds
+    }
+
+    public func elapsedSeconds(since start: DispatchTime) -> Double {
+        return Double(self.elapsedNanoseconds(since: start)) / Double(NSEC_PER_SEC)
+    }
+}
+
+public class FpsTimer {
+    private let fps : Fps
+    private let start : DispatchTime
+
+    fileprivate init(fps: Fps) {
+        self.fps = fps
+        self.start = DispatchTime.now()
+    }
+
+    deinit {
+        let end = DispatchTime.now()
+        self.fps.save(measurement: FpsMeasurement(from: start, to: end))
+    }
+}
+
+public struct FpsSnapshot {
+    private let samples: [FpsMeasurement]
+
+    fileprivate init(samples: [FpsMeasurement]) {
+        // Sort by increasing FPS (samples[0] is slowest frame, samples[len] is
+        // fastest frame).
+        self.samples = samples.sorted(by: { (fps1, fps2) -> Bool in
+            return fps1.elapsedNanoseconds() >= fps2.elapsedNanoseconds()
+        })
+    }
+
+    public func minFps() -> Double {
+        return samples.first?.fps() ?? Double.nan
+    }
+
+    public func maxFps() -> Double {
+        return samples.last?.fps() ?? Double.nan
+    }
+
+    public func fps(percentile: Double) -> Double {
+        if samples.count == 0 {
+            return Double.nan
+        }
+
+        var sample_idx = Int(Double(samples.count) * percentile)
+        if sample_idx >= samples.count {
+           sample_idx = samples.count - 1
+        }
+        return samples[sample_idx].fps()
+    }
+
+    public func meanFps() -> Double {
+        let totalNanoseconds = samples.reduce(UInt64(0)) { (elapsedNanosTotal, measurement) -> UInt64 in
+            return elapsedNanosTotal + measurement.elapsedNanoseconds()
+        }
+        let meanNanosecondsPerFrame = totalNanoseconds / UInt64(samples.count)
+        return FpsMeasurement.fps(nanosecondsPerFrame: meanNanosecondsPerFrame)
+    }
+}
+
+public protocol FpsObserver : class {
+    func changed(fps: Double)
+    func changed(fpsStats: FpsSnapshot)
+}
+
+fileprivate struct WeakFpsObserver {
+    private weak var value: FpsObserver?
+
+    init (_ value: FpsObserver) {
+        self.value = value
+    }
+
+    func get() -> FpsObserver? {
+        return self.value
+    }
+}
+
+/// This gathers Fps samples via instrumentation.  It keeps a historical
+/// record of the previous 1s of samples so that you can compute statistics
+/// (min, max, percentiles, mean, etc).
+public class Fps {
+    /// A collection of all samples gathered over the previous second
+    private var samples = [FpsMeasurement]()
+    private var previousSecond : FpsSnapshot?
+    private let snapshotThresholdSeconds = 1.0
+
+    private var observers = [WeakFpsObserver]()
+
+    public var snapshot : FpsSnapshot? {
+        get {
+            return self.previousSecond
+        }
+    }
+    
+    public func startRender() -> FpsTimer {
+        return FpsTimer(fps: self)
+    }
+
+    fileprivate func save(measurement: FpsMeasurement) {
+        samples.append(measurement)
+        let sampleWindowSeconds = samples.last!.elapsedSeconds(since: samples.first!.start)
+        if sampleWindowSeconds >= snapshotThresholdSeconds {
+            previousSecond = FpsSnapshot(samples: samples)
+            samples.removeAll(keepingCapacity: true)
+
+            for observer in observers {
+                observer.get()?.changed(fpsStats: previousSecond!)
+            }
+        }
+
+        let currentFps = measurement.fps()
+        for observer in observers {
+            observer.get()?.changed(fps: currentFps)
+        }
+    }
+
+    public func add(observer: FpsObserver) {
+        observers.append(WeakFpsObserver(observer))
+    }
+}

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -286,11 +286,13 @@ class LineCacheLocked<T> {
             .map( { $0.element })
         if !missingLines.isEmpty {
             // TODO: should we send request to core?
+#if DEBUG
             print("waiting for lines: (\(missingLines.first!), \(missingLines.last!))")
+#endif
             //TODO: this timing + printing code can come out
             // when we're comfortable with the performance and
             // the timeout duration
-            let blockTime = mach_absolute_time()
+            let blockTime = DispatchTime.now()
             inner.isWaiting = true
             inner.unlock()
             Trace.shared.trace("blockingGet", .main, .begin)
@@ -298,7 +300,7 @@ class LineCacheLocked<T> {
             Trace.shared.trace("blockingGet", .main, .end)
             inner.lock()
 
-            let elapsed = mach_absolute_time() - blockTime
+            let elapsed = DispatchTime.now().uptimeNanoseconds - blockTime.uptimeNanoseconds
 
             if inner.isWaiting {
                 print("semaphore timeout \(elapsed / 1000)us \(waitResult)")
@@ -309,7 +311,9 @@ class LineCacheLocked<T> {
                     // lock was re-acquired.
                     inner.waitingForLines.wait()
                 }
+#if DEBUG
                 print("finished waiting: \(elapsed / 1000)us \(waitResult)")
+#endif
             }
         }
 

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -887,6 +887,12 @@ Gw
                                                 </binding>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Benchmark Scrolling" id="QAT-w6-S4U">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="toggleScrollBenchmark:" target="azf-ih-6fI" id="HRQ-K7-rN1"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>

--- a/XiEditor/XiTextPlane/TextPlane.swift
+++ b/XiEditor/XiTextPlane/TextPlane.swift
@@ -61,7 +61,7 @@ class TextPlaneDemo: NSView, TextPlaneDelegate {
         renderer.drawSolidRect(x: GLfloat(dirtyRect.maxX - 10), y: GLfloat(dirtyRect.maxY - 10), width: 10, height: 10, argb: 0xff00ff00)
 
         let text = "Now is the time for all good people to come to the aid of their country. This is a very long string because I really want to fill up the window and see if we can get 60Hz"
-        let font = NSFont(name: "InconsolataGo", size: 14)!
+        let font = NSFont(name: "InconsolataGo", size: 14) ?? NSFont(name: "Monaco", size: 14)!
         let builder = TextLineBuilder(text, font: font)
         builder.addFgSpan(range: 7..<10, argb: 0xffff0000)
         let tl = builder.build(fontCache: renderer.atlas.fontCache)
@@ -80,7 +80,7 @@ protocol TextPlaneDelegate: class {
 
 /// A layer that efficiently renders text content. It is a subclass of NSOpenGLLayer,
 /// and is the main top-level integration point.
-class TextPlaneLayer : NSOpenGLLayer {
+class TextPlaneLayer : NSOpenGLLayer, FpsObserver {
     lazy var renderer: Renderer = {
         glEnable(GLenum(GL_BLEND))
         glEnable(GLenum(GL_FRAMEBUFFER_SRGB))
@@ -88,6 +88,7 @@ class TextPlaneLayer : NSOpenGLLayer {
     }()
     weak var textDelegate: TextPlaneDelegate?
 
+    var fps = Fps()
     var last: Double = 0
     var count = 0
 
@@ -97,6 +98,7 @@ class TextPlaneLayer : NSOpenGLLayer {
         if #available(OSX 10.12, *) {
             colorspace = CGColorSpace(name: CGColorSpace.linearSRGB)
         }
+        fps.add(observer: self)
     }
 
     override init(layer: Any) {
@@ -116,10 +118,29 @@ class TextPlaneLayer : NSOpenGLLayer {
             0
         ]
         return NSOpenGLPixelFormat(attributes: attr)!.cglPixelFormatObj!
-        
+    }
+
+    func changed(fps: Double) {
+        // print("Fps \(fps), ms/frame = \(1000.0 / fps)")
+    }
+
+    func changed(fpsStats stats: FpsSnapshot) {
+        print("Fps mean: \(stats.meanFps()), 99%: \(stats.fps(percentile: 0.01)), min: \(stats.minFps()), max: \(stats.maxFps())")
     }
     
+    var previousFrame : FpsTimer?
+
     override func draw(in context: NSOpenGLContext, pixelFormat: NSOpenGLPixelFormat, forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>) {
+        // We have to capture the FPS rate of successive draw calls.  This isn't
+        // great because we will have an artificially low FPS if nothing is
+        // happening and when things are happening it will by capped to VSync
+        // since this only gets called when something needs to be redrawn (no
+        // way to measure how much we exceed the refresh rate by).  This is
+        // needed because the OpenGL rendering is deferred & when it actually
+        // gets committed is out of our control (timing this method alone will
+        // yield millions of FPS).
+        previousFrame = nil
+        previousFrame = fps.startRender()
         renderer.beginDraw(size: frame.size, scale: contentsScale)
         textDelegate?.render(renderer, dirtyRect: frame)
         renderer.endDraw()

--- a/XiEditor/XiTextPlane/TextPlane.swift
+++ b/XiEditor/XiTextPlane/TextPlane.swift
@@ -121,11 +121,19 @@ class TextPlaneLayer : NSOpenGLLayer, FpsObserver {
     }
 
     func changed(fps: Double) {
-        // print("Fps \(fps), ms/frame = \(1000.0 / fps)")
+        // TODO: use a view/text label overlay within the document to show this
+        // controllable via a debug menu instead of a compile-time flag.
+#if FPS_RAW
+        print("Fps \(fps), ms/frame = \(1000.0 / fps)")
+#endif
     }
 
     func changed(fpsStats stats: FpsSnapshot) {
+        // TODO: use a view/text label overlay within the document to show this
+        // controllable via a debug menu instead of a compile-time flag.
+#if FPS_STATS
         print("Fps mean: \(stats.meanFps()), 99%: \(stats.fps(percentile: 0.01)), min: \(stats.minFps()), max: \(stats.maxFps())")
+#endif
     }
     
     var previousFrame : FpsTimer?
@@ -144,14 +152,6 @@ class TextPlaneLayer : NSOpenGLLayer, FpsObserver {
         renderer.beginDraw(size: frame.size, scale: contentsScale)
         textDelegate?.render(renderer, dirtyRect: frame)
         renderer.endDraw()
-
-        /*
-        let now = NSDate().timeIntervalSince1970
-        let elapsed = now - last
-        last = now
-        print("\(count) \(elapsed)")
-        count += 1
-        */
     }
 
 }


### PR DESCRIPTION
Measure how frequently we're rendering.  Do to the way CoreAnimation
works we'll only be able to capture FPS up to VSync since we'll never
get called faster than that to draw (the draw itself doesn't actually
capture render time since that's deferred).

Also remove the blocking lines print spew in release builds & switch to 
DispatchTime instead of mach_absolute_time for timing that part of the code.