### PR TITLE
More rational view reuse, fewer redundant redraws

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -225,7 +225,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     }
 
     func handleFontChange(fontName: String?, fontSize: CGFloat?) {
-        guard textMetrics.font.fontName != fontName || textMetrics.font.pointSize != fontSize else { return }
+        guard (textMetrics.font.fontName != fontName && textMetrics.font.familyName != fontName)
+            || textMetrics.font.pointSize != fontSize else { return }
 
         if let newFont = NSFont(name: fontName ?? textMetrics.font.fontName,
                                 size: fontSize ?? textMetrics.font.pointSize) {

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -157,6 +157,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     /// If font size or theme changes, we invalidate all views.
     func redrawEverything() {
+        visibleLines = 0..<0
         updateGutterWidth()
         updateEditViewHeight()
         lines.locked().flushAssoc()

--- a/XiEditor/XiDocumentController.swift
+++ b/XiEditor/XiDocumentController.swift
@@ -59,13 +59,14 @@ class XiDocumentController: NSDocumentController {
             if let oldId = currentDocument.coreViewIdentifier {
                 Events.CloseView(viewIdentifier: oldId).dispatch(currentDocument.dispatcher!)
             }
+            currentDocument.coreViewIdentifier = nil;
 
             Events.NewView(path: url.path).dispatchWithCallback(currentDocument.dispatcher!) { (response) in
                 DispatchQueue.main.sync {
                     currentDocument.coreViewIdentifier = response
-                    currentDocument.editViewController?.visibleLines = 0..<0
                     currentDocument.fileURL = url
                     self.setIdentifier(response, forDocument: currentDocument)
+                    currentDocument.editViewController!.redrawEverything()
                     completionHandler(currentDocument, false, nil)
                 }
             }


### PR DESCRIPTION
There was a small bug where we were incorrectly comparing new font names
to old ones, which caused us to unnecessarily redraw all views whenever
a new view was opened or a config changed.

We were also apparently relying on this behaviour to redraw the content
of redraw views, which we now do explicitly.

- fixes #130