### PR TITLE
gitignoring the xi-editor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ xcuserdata/
 .DS_Store
 build/
 .env
+xi-editor/


### PR DESCRIPTION
Seems like it will be pretty common to be managing a xi-editor folder inside of xi-mac, so gitignoring it should be useful.