### PR TITLE
Fix 138

### DIFF
--- a/XiEditor/XiDocumentController.swift
+++ b/XiEditor/XiDocumentController.swift
@@ -97,6 +97,9 @@ class XiDocumentController: NSDocumentController {
     }
 
     func setupDocument(_ document: Document, forUrl url: URL?) {
+        // we nil out this field to opt out of having NSDocument check for changes on disk when saving;
+        // we (theoretically) do that check in xi-core.
+        document.fileModificationDate = nil
         Events.NewView(path: url?.path).dispatchWithCallback(document.dispatcher!) { (response) in
             DispatchQueue.main.sync {
                 self.setIdentifier(response, forDocument: document)


### PR DESCRIPTION
A regression in some of the document handling changes; we'd previously just not set this when we did setup in `Document`.