### PR TITLE
Add tracing RPC invocations

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -55,6 +55,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     lazy fileprivate var _textMetrics = TextDrawingMetrics(font: self.fallbackFont,
                                                            textColor: self.theme.foreground)
 
+    // This is connected via Cocoa bindings to the selection state
+    // of the collecting menu item (i.e. whether or not there's a checkbox)
+    // + the enabled state of the write trace menu item (greyed out when not
+    // collecting samples).
     @objc dynamic var collectTracingSamplesEnabled : Bool {
         get {
             return Trace.shared.isEnabled()

--- a/XiEditor/Dispatcher.swift
+++ b/XiEditor/Dispatcher.swift
@@ -162,4 +162,26 @@ enum Events { // namespace
         }
         let dispatchMethod = EventDispatchMethod.async
     }
+    
+    struct TracingConfig: Event {
+        typealias Output = Void
+        let enabled: Bool
+        let method = "tracing_config"
+        var params: AnyObject? {
+            return ["enabled": enabled] as AnyObject
+        }
+        let dispatchMethod = EventDispatchMethod.async
+    }
+    
+    struct SaveTrace: Event {
+        typealias Output = Void
+        let destination: String
+        let frontendSamples : [[String: AnyObject]]
+
+        let method = "save_trace"
+        var params: AnyObject? {
+            return ["destination": destination, "frontend_samples": frontendSamples] as AnyObject
+        }
+        let dispatchMethod = EventDispatchMethod.async
+    }
 }

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -867,6 +867,24 @@ Gw
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="writeTrace:" target="7er-QZ-amI" id="rFd-ai-H9o"/>
+                                                <binding destination="azf-ih-6fI" name="enabled" keyPath="self.collectTracingSamplesEnabled" id="RqQ-74-fY3">
+                                                    <dictionary key="options">
+                                                        <string key="NSValueTransformerName">BoolToControlStateValueTransformer</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Tracing Enabled" state="on" keyEquivalent="" id="sMv-IU-fc4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <binding destination="azf-ih-6fI" name="value" keyPath="self.collectTracingSamplesEnabled" id="4jc-m2-79c">
+                                                    <dictionary key="options">
+                                                        <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                        <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                        <bool key="NSValidatesImmediately" value="YES"/>
+                                                        <string key="NSValueTransformerName">BoolToControlStateValueTransformer</string>
+                                                    </dictionary>
+                                                </binding>
                                             </connections>
                                         </menuItem>
                                     </items>
@@ -893,6 +911,7 @@ Gw
                 <customObject id="7er-QZ-amI" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <customObject id="o5o-AY-Tmr" customClass="NSFontManager"/>
                 <customObject id="azf-ih-6fI" customClass="AppDelegate" customModule="XiEditor" customModuleProvider="target"/>
+                <userDefaultsController id="yco-8S-n0A"/>
             </objects>
             <point key="canvasLocation" x="-295" y="-593"/>
         </scene>

--- a/XiEditor/Trace.swift
+++ b/XiEditor/Trace.swift
@@ -102,26 +102,6 @@ class Trace {
 
         return result
     }
-
-    func write(_ destination: Writeable) {
-        mutex.lock()
-        defer {
-            mutex.unlock()
-        }
-
-        let pid = getpid()
-        destination.write(Data("[\n".utf8))
-        for entry_num in max(0, n_entries - BUF_SIZE) ..< n_entries {
-            let i = entry_num % BUF_SIZE
-            let ts = buf[i].abstime * mach_time_numer / mach_time_denom
-            let comma = entry_num == n_entries - 1 ? "" : ","
-            destination.write(Data("""
-                {"name": "\(buf[i].name)", "cat": "\(buf[i].cat)", "ph": "\(buf[i].ph.rawValue)", \
-                "pid": \(pid), "tid": \(buf[i].tid), "ts": \(ts)}\(comma)\n
-                """.utf8))
-        }
-        destination.write(Data("]\n".utf8))
-    }
 }
 
 enum TraceCategory: String {

--- a/XiEditor/Trace.swift
+++ b/XiEditor/Trace.swift
@@ -17,6 +17,10 @@
 
 import Foundation
 
+protocol Writeable {
+    func write(_ data: Data)
+}
+
 /// Collect trace events so they can be output in Chrome tracing format.
 class Trace {
     let mutex = UnfairLock()
@@ -25,6 +29,7 @@ class Trace {
     var n_entries = 0
     let mach_time_numer: UInt64
     let mach_time_denom: UInt64
+    var enabled = false
 
     /// Shared instance, most uses should call this.
     static var shared = Trace()
@@ -37,9 +42,33 @@ class Trace {
         // the 1000 is because mach time is ns, and chrome tracing time is us
         mach_time_denom = UInt64(info.denom) * 1000
     }
+    
+    func isEnabled() -> Bool {
+        mutex.lock()
+        defer {
+            mutex.unlock()
+        }
+        return self.enabled
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        mutex.lock()
+        defer {
+            mutex.unlock()
+        }
+        self.enabled = enabled
+        self.n_entries = 0
+    }
 
     func trace(_ name: String, _ cat: TraceCategory, _ ph: TracePhase) {
         mutex.lock()
+        defer {
+            mutex.unlock()
+        }
+
+        if !self.enabled {
+            return
+        }
         let i = n_entries % BUF_SIZE
         buf[i].name = name
         buf[i].cat = cat
@@ -47,32 +76,51 @@ class Trace {
         buf[i].abstime = mach_absolute_time()
         pthread_threadid_np(nil, &buf[i].tid)
         n_entries += 1
-        mutex.unlock()
     }
 
-    // TODO: more control over where this gets saved
-    func write() {
+    func snapshot() -> [[String: AnyObject]] {
+        mutex.lock()
+        defer {
+            mutex.unlock()
+        }
+
+        var result : [[String: AnyObject]] = []
+        
         let pid = getpid()
-        let path = "/tmp/xi-trace-\(pid)"
-        if !FileManager.default.createFile(atPath: path, contents: nil, attributes: nil) {
-            print("error creating trace file")
-            return
+
+        for entry_num in max(0, n_entries - BUF_SIZE) ..< n_entries {
+            let i = entry_num % BUF_SIZE
+            let ts = buf[i].abstime * mach_time_numer / mach_time_denom
+            result.append([
+                "name": buf[i].name as NSString,
+                "cat": buf[i].cat.rawValue as NSString,
+                "ph": buf[i].ph.rawValue as NSString,
+                "pid": NSNumber(value: pid) as AnyObject,
+                "tid": NSNumber(value: buf[i].tid) as AnyObject,
+                "ts": NSNumber(value: ts) as AnyObject])
         }
-        guard let fh = FileHandle(forWritingAtPath: path) else {
-            print("error opening trace file for writing")
-            return
+
+        return result
+    }
+
+    func write(_ destination: Writeable) {
+        mutex.lock()
+        defer {
+            mutex.unlock()
         }
-        fh.write(Data("[\n".utf8))
+
+        let pid = getpid()
+        destination.write(Data("[\n".utf8))
         for entry_num in max(0, n_entries - BUF_SIZE) ..< n_entries {
             let i = entry_num % BUF_SIZE
             let ts = buf[i].abstime * mach_time_numer / mach_time_denom
             let comma = entry_num == n_entries - 1 ? "" : ","
-            fh.write(Data("""
-                  {"name": "\(buf[i].name)", "cat": "\(buf[i].cat)", "ph": "\(buf[i].ph.rawValue)", \
+            destination.write(Data("""
+                {"name": "\(buf[i].name)", "cat": "\(buf[i].cat)", "ph": "\(buf[i].ph.rawValue)", \
                 "pid": \(pid), "tid": \(buf[i].tid), "ts": \(ts)}\(comma)\n
                 """.utf8))
         }
-        fh.write(Data("]\n".utf8))
+        destination.write(Data("]\n".utf8))
     }
 }
 


### PR DESCRIPTION
Pop-up a save dialog when requesting to write a trace.
Add support in front-end tracing for enabled/disabled (disabled
default).
Hard-code tracing to be on upon launch by default for now.
Add RPC hooks to control on/off for tracing + save.