### PR TITLE
actions cleanup

### DIFF
--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -345,67 +345,6 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
 
     /// MARK: - System Events
 
-    // Mapping of selectors to simple no-parameter commands.
-    static let selectorToCommand = [
-        "deleteBackward:": "delete_backward",
-        "deleteForward:": "delete_forward",
-        "deleteToBeginningOfLine:": "delete_to_beginning_of_line",
-        "deleteToEndOfParagraph:": "delete_to_end_of_paragraph",
-        "deleteWordBackward:": "delete_word_backward",
-        "deleteWordForward:": "delete_word_forward",
-        "insertNewline:": "insert_newline",
-        "insertTab:": "insert_tab",
-        "moveBackward:": "move_backward",
-        "moveDown:": "move_down",
-        "moveDownAndModifySelection:": "move_down_and_modify_selection",
-        "moveForward:": "move_forward",
-        "moveLeft:": "move_left",
-        "moveLeftAndModifySelection:": "move_left_and_modify_selection",
-        "moveRight:": "move_right",
-        "moveRightAndModifySelection:": "move_right_and_modify_selection",
-        "moveToBeginningOfDocument:": "move_to_beginning_of_document",
-        "moveToBeginningOfDocumentAndModifySelection:": "move_to_beginning_of_document_and_modify_selection",
-        "moveToBeginningOfParagraph:": "move_to_beginning_of_paragraph",
-        "moveToEndOfDocument:": "move_to_end_of_document",
-        "moveToEndOfDocumentAndModifySelection:": "move_to_end_of_document_and_modify_selection",
-        "moveToEndOfParagraph:": "move_to_end_of_paragraph",
-        "moveToLeftEndOfLine:": "move_to_left_end_of_line",
-        "moveToLeftEndOfLineAndModifySelection:": "move_to_left_end_of_line_and_modify_selection",
-        "moveToRightEndOfLine:": "move_to_right_end_of_line",
-        "moveToRightEndOfLineAndModifySelection:": "move_to_right_end_of_line_and_modify_selection",
-        "moveUp:": "move_up",
-        "moveUpAndModifySelection:": "move_up_and_modify_selection",
-        "moveWordLeft:": "move_word_left",
-        "moveWordLeftAndModifySelection:": "move_word_left_and_modify_selection",
-        "moveWordRight:": "move_word_right",
-        "moveWordRightAndModifySelection:": "move_word_right_and_modify_selection",
-        "pageDownAndModifySelection:": "page_down_and_modify_selection",
-        "pageUpAndModifySelection:": "page_up_and_modify_selection",
-        "scrollPageDown:": "scroll_page_down",
-        "scrollPageUp:": "scroll_page_up",
-        // Note: these next two are mappings. Possible TODO to fix if core provides distinct behaviors
-        "scrollToBeginningOfDocument:": "move_to_beginning_of_document",
-        "scrollToEndOfDocument:": "move_to_end_of_document",
-        "transpose:": "transpose",
-        "yank:": "yank",
-        "cancelOperation:": "cancel_operation",
-        "uppercaseWord:": "uppercase",
-        "lowercaseWord:": "lowercase",
-    ]
-
-    override func doCommand(by aSelector: Selector) {
-        if (self.responds(to: aSelector)) {
-            super.doCommand(by: aSelector);
-        } else {
-            if let commandName = EditView.selectorToCommand[aSelector.description] {
-                dataSource.document.sendRpcAsync(commandName, params: []);
-            } else {
-                Swift.print("Unhandled selector: \(aSelector.description)")
-                NSSound.beep()
-            }
-        }
-    }
-
     /// timer callback to toggle the blink state
     @objc func _blinkInsertionPoint() {
         _cursorStateOn = !_cursorStateOn

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -204,6 +204,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     // MARK: - System Events
 
     /// Mapping of selectors to simple no-parameter commands.
+    /// This map contains all commands that are *not* exposed via application menus.
+    /// Commands which have menu items must be implemented individually, to play nicely
+    /// With menu activation.
     static let selectorToCommand = [
         "deleteBackward:": "delete_backward",
         "deleteForward:": "delete_forward",
@@ -247,13 +250,14 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         "transpose:": "transpose",
         "yank:": "yank",
         "cancelOperation:": "cancel_operation",
-        "uppercaseWord:": "uppercase",
-        "lowercaseWord:": "lowercase",
         ]
     
     override func doCommand(by aSelector: Selector) {
+        // Although this function is only called when a command originates in a keyboard event,
+        // several commands (such as uppercaseWord:) are accessible from both a system binding
+        // _and_ a menu; if there's a concrete implementation of such a method we just call it directly.
         if (self.responds(to: aSelector)) {
-            super.doCommand(by: aSelector);
+            self.perform(aSelector)
         } else {
             if let commandName = EditViewController.selectorToCommand[aSelector.description] {
                 document.sendRpcAsync(commandName, params: []);

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -202,6 +202,68 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
     
     // MARK: - System Events
+
+    /// Mapping of selectors to simple no-parameter commands.
+    static let selectorToCommand = [
+        "deleteBackward:": "delete_backward",
+        "deleteForward:": "delete_forward",
+        "deleteToBeginningOfLine:": "delete_to_beginning_of_line",
+        "deleteToEndOfParagraph:": "delete_to_end_of_paragraph",
+        "deleteWordBackward:": "delete_word_backward",
+        "deleteWordForward:": "delete_word_forward",
+        "insertNewline:": "insert_newline",
+        "insertTab:": "insert_tab",
+        "moveBackward:": "move_backward",
+        "moveDown:": "move_down",
+        "moveDownAndModifySelection:": "move_down_and_modify_selection",
+        "moveForward:": "move_forward",
+        "moveLeft:": "move_left",
+        "moveLeftAndModifySelection:": "move_left_and_modify_selection",
+        "moveRight:": "move_right",
+        "moveRightAndModifySelection:": "move_right_and_modify_selection",
+        "moveToBeginningOfDocument:": "move_to_beginning_of_document",
+        "moveToBeginningOfDocumentAndModifySelection:": "move_to_beginning_of_document_and_modify_selection",
+        "moveToBeginningOfParagraph:": "move_to_beginning_of_paragraph",
+        "moveToEndOfDocument:": "move_to_end_of_document",
+        "moveToEndOfDocumentAndModifySelection:": "move_to_end_of_document_and_modify_selection",
+        "moveToEndOfParagraph:": "move_to_end_of_paragraph",
+        "moveToLeftEndOfLine:": "move_to_left_end_of_line",
+        "moveToLeftEndOfLineAndModifySelection:": "move_to_left_end_of_line_and_modify_selection",
+        "moveToRightEndOfLine:": "move_to_right_end_of_line",
+        "moveToRightEndOfLineAndModifySelection:": "move_to_right_end_of_line_and_modify_selection",
+        "moveUp:": "move_up",
+        "moveUpAndModifySelection:": "move_up_and_modify_selection",
+        "moveWordLeft:": "move_word_left",
+        "moveWordLeftAndModifySelection:": "move_word_left_and_modify_selection",
+        "moveWordRight:": "move_word_right",
+        "moveWordRightAndModifySelection:": "move_word_right_and_modify_selection",
+        "pageDownAndModifySelection:": "page_down_and_modify_selection",
+        "pageUpAndModifySelection:": "page_up_and_modify_selection",
+        "scrollPageDown:": "scroll_page_down",
+        "scrollPageUp:": "scroll_page_up",
+        // Note: these next two are mappings. Possible TODO to fix if core provides distinct behaviors
+        "scrollToBeginningOfDocument:": "move_to_beginning_of_document",
+        "scrollToEndOfDocument:": "move_to_end_of_document",
+        "transpose:": "transpose",
+        "yank:": "yank",
+        "cancelOperation:": "cancel_operation",
+        "uppercaseWord:": "uppercase",
+        "lowercaseWord:": "lowercase",
+        ]
+    
+    override func doCommand(by aSelector: Selector) {
+        if (self.responds(to: aSelector)) {
+            super.doCommand(by: aSelector);
+        } else {
+            if let commandName = EditViewController.selectorToCommand[aSelector.description] {
+                document.sendRpcAsync(commandName, params: []);
+            } else {
+                Swift.print("Unhandled selector: \(aSelector.description)")
+                NSSound.beep()
+            }
+        }
+    }
+
     override func keyDown(with theEvent: NSEvent) {
         self.editView.inputContext?.handleEvent(theEvent);
     }


### PR DESCRIPTION
This was... much more annoying than I expected.

In any case this moves all action handling into the view controller, and introduces the following distinction:

* Any command which is present as a menu item is implemented as a stand alone method;
* Any command that is available _only_ through a keybinding is implemented using the method map;
* If a command is available both as a menu item _and_ a keybinding (a system key binding, not a menu key binding) then `doCommand` forwards any invocations to the specific method.

This isn't as totally clear as we'd like but I've tried to document it inline.

This also includes a bit of tidying up; the only functional changes are in the second commit.

closes #147 