### PR TITLE
Capture core stderr and writes to log on core crash

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -141,6 +141,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         return applicationDirectory
     }()
     
+    // The default name for XiEditor's error logs
+    let defaultCoreLogName = "xi_tmp.log"
+    
     lazy var errorLogDirectory: URL = {
         let logDirectory = FileManager.default.urls(
         for: .libraryDirectory,
@@ -217,7 +220,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     
     // Clean up temporary Xi stderr log
     func applicationWillTerminate(_ notification: Notification) {
-        let tmpErrLogFile = errorLogDirectory.appendingPathComponent("xi_tmp.log")
+        let tmpErrLogFile = errorLogDirectory.appendingPathComponent(defaultCoreLogName)
         do {
             try FileManager.default.removeItem(at: tmpErrLogFile)
         } catch let err as NSError {
@@ -416,6 +419,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
             Events.SaveTrace(destination: destination, frontendSamples: Trace.shared.snapshot()).dispatch(self.dispatcher!)
         }
     }
+    
     @IBAction func openErrorLogFolder(_ sender: Any) {
         NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: errorLogDirectory.path)
     }

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -217,7 +217,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     
     // Clean up temporary Xi stderr log
     func applicationWillTerminate(_ notification: Notification) {
-        let tmpErrLogFile = errorLogDirectory.appendingPathComponent("xi_tmp.err")
+        let tmpErrLogFile = errorLogDirectory.appendingPathComponent("xi_tmp.log")
         do {
             try FileManager.default.removeItem(at: tmpErrLogFile)
         } catch let err as NSError {

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -217,7 +217,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     
     // Clean up temporary Xi stderr log
     func applicationWillTerminate(_ notification: Notification) {
-        
         let tmpErrLogFile = errorLogDirectory.appendingPathComponent("xi_tmp.err")
         do {
             try FileManager.default.removeItem(at: tmpErrLogFile)

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -192,6 +192,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         Trace.shared.trace("appWillLaunch", .main, .end)
         documentController = XiDocumentController()
     }
+    
+    func applicationWillTerminate(_ notification: Notification) {
+        let libraryDirectory = FileManager.default.urls(for: .libraryDirectory,
+                                                        in: .userDomainMask).first!
+        
+        let tmpErrLogPath = libraryDirectory.appendingPathComponent("Logs").appendingPathComponent("xi_mac.err")
+        do {
+            try FileManager.default.removeItem(at: tmpErrLogPath)
+        } catch let err as NSError {
+            print("No temporary log found. \(err)")
+        }
+    }
 
     // MARK: - XiClient protocol
 

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -83,7 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     var documentController: XiDocumentController!
 
     // This is set to 'InconsolataGo' in the user preferences; this value is a fallback.
-    let fallbackFont = CTFontCreateWithName(("Inconsolata" as CFString?)!, 14, nil)
+    let fallbackFont = CTFontCreateWithName(("Menlo" as CFString?)!, 14, nil)
 
     lazy fileprivate var _textMetrics = TextDrawingMetrics(font: self.fallbackFont,
                                                            textColor: self.theme.foreground)
@@ -148,19 +148,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         let logDirectory = FileManager.default.urls(
             for: .libraryDirectory,
             in: .userDomainMask)
-            .first!
+            .first?
             .appendingPathComponent("Logs")
             .appendingPathComponent("XiEditor")
-        
+
         // create XiEditor log folder on first run
-        do {
-            try FileManager.default.createDirectory(at: logDirectory,
-                                                    withIntermediateDirectories: true,
-                                                    attributes: nil)
-        } catch let err as NSError {
-            print("failed to create error log directory. \(err)")
-            return nil
-        }
+        guard logDirectory != nil else { return nil }
+        try? FileManager.default.createDirectory(at: logDirectory!,
+                                                 withIntermediateDirectories: true,
+                                                 attributes: nil)
         return logDirectory
     }()
 

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -154,9 +154,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
 
         // create XiEditor log folder on first run
         guard logDirectory != nil else { return nil }
-        try? FileManager.default.createDirectory(at: logDirectory!,
-                                                 withIntermediateDirectories: true,
-                                                 attributes: nil)
+        do {
+            try FileManager.default.createDirectory(at: logDirectory!,
+                                                     withIntermediateDirectories: true,
+                                                     attributes: nil)
+        } catch {
+            // Returns nil if the log directory can't be created
+            return nil
+        }
         return logDirectory
     }()
 

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -141,7 +141,7 @@ class CoreConnection {
                 print("failed to rename file with error: \(error)")
             }
             
-            print(self.errOutput)
+            print("xi-core has closed, writing to log at XiEditor_\(timeStamp).err")
             self.errLogWriter?.write(bytes: self.errOutput.data(using: String.Encoding.utf8)!)
         }
         

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -113,11 +113,9 @@ class CoreConnection {
             dateFormatter.dateFormat = "yyyy-MM-dd-HHMMSS"
             let timeStamp = dateFormatter.string(from: currentTime)
 
-            guard let tmpErrLog = self.appDelegate.errorLogDirectory?.appendingPathComponent(self.appDelegate.defaultCoreLogName)
+            guard let tmpErrLog = self.appDelegate.errorLogDirectory?.appendingPathComponent(self.appDelegate.defaultCoreLogName),
+                let timestampedLog = self.appDelegate.errorLogDirectory?.appendingPathComponent("XiEditor_\(timeStamp).log")
                 else { return }
-            guard let timestampedLog = self.appDelegate.errorLogDirectory?.appendingPathComponent("XiEditor_\(timeStamp).log")
-                else { return }
-            
             do {
                 try FileManager.default.moveItem(at: tmpErrLog, to: timestampedLog)
             } catch let error as NSError {

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -80,7 +80,7 @@ class CoreConnection {
             self.rpcLogWriter = nil
         }
         
-        let tmpErrLog = logDirectory.appendingPathComponent("xi_tmp.err").path
+        let tmpErrLog = logDirectory.appendingPathComponent("xi_tmp.log").path
         
         self.errLogWriter = FileWriter(path: tmpErrLog)
         if self.errLogWriter != nil {
@@ -107,8 +107,6 @@ class CoreConnection {
             let data = handle.availableData
             var lineCount = 1
             
-            self.errLogWriter?.write(bytes: data)
-            
             if let errString = String(data: data, encoding: String.Encoding.utf8) {
                 print(errString, terminator: "")
                 self.errOutput += errString
@@ -116,7 +114,6 @@ class CoreConnection {
             
             if self.errOutput.hasSuffix("\n") {
                 lineCount += 1
-                
                 if lineCount >= 100 {
                     self.errOutput = ""
                     lineCount = 1
@@ -132,8 +129,8 @@ class CoreConnection {
             dateFormatter.dateFormat = "yyyy-MM-dd-HHMMSS"
             let timeStamp = dateFormatter.string(from: currentTime)
             
-            let tmpErrLog = self.logDirectory.appendingPathComponent("xi_tmp.err")
-            let timestampedLog = self.logDirectory.appendingPathComponent("XiEditor_\(timeStamp).err")
+            let tmpErrLog = self.logDirectory.appendingPathComponent("xi_tmp.log")
+            let timestampedLog = self.logDirectory.appendingPathComponent("XiEditor_\(timeStamp).log")
             
             do {
                 try FileManager.default.moveItem(at: tmpErrLog, to: timestampedLog)
@@ -141,7 +138,7 @@ class CoreConnection {
                 print("failed to rename file with error: \(error)")
             }
             
-            print("xi-core has closed, writing to log at XiEditor_\(timeStamp).err")
+            print("xi-core has closed, writing to log at XiEditor_\(timeStamp).log")
             self.errLogWriter?.write(bytes: self.errOutput.data(using: String.Encoding.utf8)!)
         }
         

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -54,10 +54,14 @@ class CoreConnection {
     weak var client: XiClient?
     let rpcLogWriter: FileWriter?
     let errLogWriter: FileWriter?
-    let logDirectory = FileManager.default.urls(for: .libraryDirectory,
-                                                in: .userDomainMask)
-                                                .first!
-                                                .appendingPathComponent("Logs") // default log directory on MacOS (/Library/Logs)
+    
+    // default log directory on MacOS is /Library/Logs
+    let logDirectory = FileManager.default.urls(
+        for: .libraryDirectory,
+        in: .userDomainMask)
+        .first!
+        .appendingPathComponent("Logs")
+        .appendingPathComponent("XiEditor")
     
     // RPC state
     var queue = DispatchQueue(label: "com.levien.xi.CoreConnection", attributes: [])
@@ -76,10 +80,11 @@ class CoreConnection {
             self.rpcLogWriter = nil
         }
         
-        let tmpErrLogPath = logDirectory.appendingPathComponent("xi_mac.err").path
-        self.errLogWriter = FileWriter(path: tmpErrLogPath)
+        let tmpErrLog = logDirectory.appendingPathComponent("xi_tmp.err").path
+        
+        self.errLogWriter = FileWriter(path: tmpErrLog)
         if self.errLogWriter != nil {
-            print("logging stderr to \(tmpErrLogPath)")
+            print("logging stderr to \(tmpErrLog)")
         }
           
         task.launchPath = path
@@ -133,11 +138,11 @@ class CoreConnection {
                     dateFormatter.dateFormat = "yyyy-MM-dd-HHMMSS"
                     let timeStamp = dateFormatter.string(from: currentTime)
                     
-                    let tmpErrLogPath = self.logDirectory.appendingPathComponent("xi_mac.err")
-                    let timestampedLogPath = self.logDirectory.appendingPathComponent("XiEditor_\(timeStamp).err")
+                    let tmpErrLog = self.logDirectory.appendingPathComponent("xi_tmp.err")
+                    let timestampedLog = self.logDirectory.appendingPathComponent("XiEditor_\(timeStamp).err")
                     
                     do {
-                        try FileManager.default.moveItem(at: tmpErrLogPath, to: timestampedLogPath)
+                        try FileManager.default.moveItem(at: tmpErrLog, to: timestampedLog)
                     } catch let error as NSError {
                         print("failed to rename file with error: \(error)")
                     }

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -893,6 +893,12 @@ Gw
                                                 <action selector="toggleScrollBenchmark:" target="azf-ih-6fI" id="HRQ-K7-rN1"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Open Error Log Folder" id="R0h-rI-8o1">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="openErrorLogFolder:" target="azf-ih-6fI" id="dlx-rd-R59"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>


### PR DESCRIPTION
This PR is meant to address issue #136.

A handler is added to capture stderr output from xi-core and print it into Xcode's console. When xi-core crashes or terminates, a log of stderr output is dumped to the user's /Library/Logs/XiEditor folder with a timestamp in its filename. 

A button to open the log folder has also been added to the debug menu.