### PR TITLE
frontend implementations of indent and outdent

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -342,6 +342,14 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     @objc func copy(_ sender: AnyObject?) {
         cutCopy("copy")
     }
+
+    override func indent(_ sender: Any?) {
+        document.sendRpcAsync("indent", params: [])
+    }
+
+    @objc func outdent(_ sender: Any?) {
+        document.sendRpcAsync("outdent", params: [])
+    }
     
     fileprivate func cutCopy(_ method: String) {
         let text = document?.sendRpc(method, params: [])

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -347,7 +347,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         document.sendRpcAsync("indent", params: [])
     }
 
-    @objc func outdent(_ sender: Any?) {
+    @objc func unindent(_ sender: Any?) {
         document.sendRpcAsync("outdent", params: [])
     }
     

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -758,9 +758,9 @@ Gw
                                                             <action selector="indent:" target="7er-QZ-amI" id="vTx-qv-4AV"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Outdent" keyEquivalent="[" id="bhP-6q-co4">
+                                                    <menuItem title="Unindent" keyEquivalent="[" id="bhP-6q-co4" userLabel="Unindent">
                                                         <connections>
-                                                            <action selector="outdent:" target="7er-QZ-amI" id="Ak2-Ut-opO"/>
+                                                            <action selector="unindent:" target="7er-QZ-amI" id="83I-gO-x7f"/>
                                                         </connections>
                                                     </menuItem>
                                                 </items>

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -752,6 +752,17 @@ Gw
                                                             <action selector="pasteRuler:" target="7er-QZ-amI" id="5VN-HF-Y7C"/>
                                                         </connections>
                                                     </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="cFX-wO-Pxl"/>
+                                                    <menuItem title="Indent" keyEquivalent="]" id="uVM-IT-1r0" userLabel="Indent">
+                                                        <connections>
+                                                            <action selector="indent:" target="7er-QZ-amI" id="vTx-qv-4AV"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Outdent" keyEquivalent="[" id="bhP-6q-co4">
+                                                        <connections>
+                                                            <action selector="outdent:" target="7er-QZ-amI" id="Ak2-Ut-opO"/>
+                                                        </connections>
+                                                    </menuItem>
                                                 </items>
                                             </menu>
                                         </menuItem>


### PR DESCRIPTION
This is a companion PR to xi-editor's PR [#586](https://github.com/google/xi-editor/pull/586). This PR adds 2 menu items that accompanies the indent and outdent functions. The default hotkeys are Cmd+] and Cmd+[ for indent and outdent respectively.