### PR TITLE
Implement unified titlebar preference

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -131,6 +131,25 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
             }
         }
     }
+  
+    var unifiedTitlebar = false {
+        didSet {
+            // Dont check if value is same as previous
+            // so when theme updates, background color still changes
+            if let window = self.view.window {
+                let color = self.theme.background
+        
+                window.titlebarAppearsTransparent = unifiedTitlebar
+                window.backgroundColor = unifiedTitlebar ? color : nil
+        
+            if color.isDark && unifiedTitlebar {
+                window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
+            } else {
+                window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
+            }
+      }
+    }
+  }
 
     private var lastDragPosition: BufferPosition?
     /// handles autoscrolling when a drag gesture exists the window
@@ -506,6 +525,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
             case "scroll_past_end":
                 self.scrollPastEnd = changes["scroll_past_end"] as! Bool
+            
+            case "unified_titlebar":
+                self.unifiedTitlebar = changes["unified_titlebar"] as! Bool
                 
             default:
                 break
@@ -592,6 +614,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         for subItem in (pluginsMenu?.submenu!.items)! {
             subItem.state = NSControl.StateValue(rawValue: (subItem.title == theme) ? 1 : 0)
         }
+        self.unifiedTitlebar = { self.unifiedTitlebar }()
     }
 
     @IBAction func gotoLine(_ sender: AnyObject) {
@@ -640,3 +663,16 @@ extension EditViewController: NSWindowDelegate {
         editView.isFrontmostView = false
     }
 }
+
+extension NSColor {
+    var isDark: Bool {
+        let red = self.redComponent
+        let green = self.greenComponent
+        let blue = self.blueComponent
+    
+        // Formula taken from https://www.w3.org/WAI/ER/WD-AERT/#color-contrast
+        let brightness = ((red * 299) + (green * 587) + (blue * 114)) / 1000
+        return brightness < 0.5
+    }
+}
+

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -145,7 +145,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
                 if color.isDark && unifiedTitlebar {
                     window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
                 } else {
-                window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
+                    window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
                 }
             }
         }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -142,14 +142,14 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
                 window.titlebarAppearsTransparent = unifiedTitlebar
                 window.backgroundColor = unifiedTitlebar ? color : nil
         
-            if color.isDark && unifiedTitlebar {
-                window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
-            } else {
+                if color.isDark && unifiedTitlebar {
+                    window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
+                } else {
                 window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
+                }
             }
-      }
+        }
     }
-  }
 
     private var lastDragPosition: BufferPosition?
     /// handles autoscrolling when a drag gesture exists the window


### PR DESCRIPTION
Similar to other editors (Sublime, Atom...) a unified titlebar is a nice thing to have.

This can be set in preferences with `unified_titlebar = true`, and when the theme changes, the titlebar adapts as seen in the gif below:

![xi](https://user-images.githubusercontent.com/20056300/38243217-21016d34-377a-11e8-888f-87730cc8bd53.gif)

If the current theme is dark (see the new NSColor extension), the windows appearance is set to `vibrantDark`, which also darkens other UI things such as the find input bar. I think this is a nice touch, but if its not wanted, I can remove it.

This also works for tabs:

<img width="949" alt="screen shot 2018-04-03 at 8 09 28 pm" src="https://user-images.githubusercontent.com/20056300/38243468-f5264936-377a-11e8-9eed-410dcd8cf5ed.png">
