### PR TITLE
Add measure_width implementation

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -317,6 +317,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
+    func measureWidth(args: [[String : AnyObject]]) -> [[Double]] {
+        return styleMap.locked().measureWidths(args)
+    }
+
     //MARK: - top-level interactions
     @IBAction func openPreferences(_ sender: NSMenuItem) {
         let delegate = (NSApplication.shared.delegate as? AppDelegate)

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -59,4 +59,9 @@ protocol XiClient: AnyObject {
     // config keys and their values. Subsequent calls contain only those items which
     // have changed since the previous call.
     func configChanged(viewIdentifier: String, changes: [String: AnyObject])
+
+    /// A request to measure the width of strings. Each item in the list is a dictionary
+    /// where `style` is the id of the style and `strings` is an array of strings to
+    /// measure. The result is an array of arrays of width measurements, in macOS "points".
+    func measureWidth(args: [[String: AnyObject]]) -> [[Double]]
 }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -442,7 +442,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     @IBAction func debugRewrap(_ sender: AnyObject) {
         document.sendRpcAsync("debug_rewrap", params: [])
     }
-    
+
+    @IBAction func debugWrapWidth(_ sender: AnyObject) {
+        document.sendRpcAsync("debug_wrap_width", params: [])
+    }
+
     @IBAction func debugSetTheme(_ sender: NSMenuItem) {
         guard sender.state != NSControl.StateValue.on else { print("theme already active"); return }
         let req = Events.SetTheme(themeName: sender.title)

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -191,7 +191,7 @@ Gw
                                 <rect key="frame" x="8" y="0.0" width="464" height="38"/>
                                 <subviews>
                                     <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yjF-1R-sp7" customClass="FindSearchField" customModule="XiEditor" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="8" width="363" height="22"/>
+                                        <rect key="frame" x="0.0" y="8" width="365" height="22"/>
                                         <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" focusRingType="none" bezelStyle="round" recentsAutosaveName="xi-editor-find" id="4a0-aC-Kre">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -207,7 +207,7 @@ Gw
                                         </connections>
                                     </searchField>
                                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="usm-aH-bgF">
-                                        <rect key="frame" x="370" y="9" width="43" height="20"/>
+                                        <rect key="frame" x="372" y="9" width="41" height="20"/>
                                         <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="53c-PL-hc5">
                                             <font key="font" metaFont="cellTitle"/>
                                             <segments>
@@ -810,6 +810,12 @@ Gw
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="debugRewrap:" target="7er-QZ-amI" id="qoT-pS-n4J"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Wrap with width" keyEquivalent="" id="QGA-8o-1cd">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="debugWrapWidth:" target="7er-QZ-amI" id="dBT-8g-4c9"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Print Selection Spans" keyEquivalent="" id="8QK-XZ-5IS">

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -203,6 +203,23 @@ class StyleMapState: UnfairLock {
                   underline: $0.underline, italic: $0.italic, weight: $0.weight)
         } }
     }
+
+    func measureWidth(id: Int, s: String) -> Double {
+        let builder = TextLineBuilder(s, font: self.font)
+        let range = NSMakeRange(0, s.utf16.count)
+        applyStyle(builder: builder, id: id, range: range)
+        return builder.measure()
+    }
+
+    func measureWidths(_ args: [[String: AnyObject]]) -> [[Double]] {
+        return args.map({(arg: [String: AnyObject]) -> [Double] in
+            guard let id = arg["id"] as? Int, let strings = arg["strings"] as? [String] else {
+                print("invalid measure_widths request")
+                return []
+            }
+            return strings.map({(s: String) -> Double in measureWidth(id: id, s: s)})
+        })
+    }
 }
 
 /// Safe access to the style map, holding a lock
@@ -230,6 +247,10 @@ class StyleMapLocked {
 
     func updateFont(to font: NSFont) {
         inner.updateFont(to: font)
+    }
+
+    func measureWidths(_ args: [[String: AnyObject]]) -> [[Double]] {
+        return inner.measureWidths(args)
     }
 }
 

--- a/XiEditor/XiTextPlane/TextLine.swift
+++ b/XiEditor/XiTextPlane/TextLine.swift
@@ -151,6 +151,12 @@ class TextLineBuilder {
         }
         return TextLine(glyphs: glyphs, ctLine: ctLine, selRanges: selRanges, underlineRanges: underlineRanges, width: nil)
     }
+
+    /// Measure the total width of the line. Should be consistent with `.build().width`
+    func measure() -> Double {
+        let ctLine = CTLineCreateWithAttributedString(attrString)
+        return CTLineGetTypographicBounds(ctLine, nil, nil, nil)
+    }
 }
 
 /// A line of text with attributes that is ready for drawing.


### PR DESCRIPTION
Adds a method to measure the widths of strings, and exposes it through
RPC. Also adds a debug wrap with width. To be applied in combination
with google/xi-editor#607

Part of google/xi-editor#565