### PR TITLE
Set minimum window size

### DIFF
--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -89,7 +89,7 @@ class Document: NSDocument {
         }
         
         windowController.window?.setFrame(newFrame, display: true)
-        windowController.window?.minSize = NSSize(width: 200, height: 100)
+        windowController.window?.minSize = newFrame.size
 
         self.editViewController = windowController.contentViewController as? EditViewController
         editViewController?.document = self

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -35,6 +35,9 @@ class Document: NSDocument {
     /// if set, should be used as the tabbingIdentifier of new documents' windows.
     static var preferredTabbingIdentifier: String?
 
+    // minimum size for a new or resized window
+    static var minWinSize = NSSize(width: 240, height: 160)
+
     var dispatcher: Dispatcher!
     
     /// coreViewIdentifier is the name used to identify this document when communicating with the Core.
@@ -89,7 +92,7 @@ class Document: NSDocument {
         }
         
         windowController.window?.setFrame(newFrame, display: true)
-        windowController.window?.minSize = newFrame.size
+        windowController.window?.minSize = Document.minWinSize
 
         self.editViewController = windowController.contentViewController as? EditViewController
         editViewController?.document = self
@@ -178,7 +181,7 @@ class Document: NSDocument {
             editVC.updateAsync(update: update)
         }
     }
-    
+
     /// Returns the frame to be used for the next new window.
     ///
     /// - Note: This is the position of the last active window, offset
@@ -197,15 +200,12 @@ class Document: NSDocument {
             nextFrame.origin.y = screenBounds.maxY - nextFrame.height
         }
 
-        let minNewWindowHeight: CGFloat = 160
-        let minNewWindowWidth: CGFloat = 240
-
-        nextFrame.size.width = max(nextFrame.width, minNewWindowWidth)
+        nextFrame.size.width = max(nextFrame.width, Document.minWinSize.width)
         // the origin is in the bottom left so a height change changes it too:
-        if nextFrame.size.height < minNewWindowHeight {
+        if nextFrame.size.height < Document.minWinSize.height {
             let oldHeight = nextFrame.size.height
-            nextFrame.size.height = minNewWindowHeight
-            nextFrame.origin.y = nextFrame.origin.y - (minNewWindowHeight - oldHeight)
+            nextFrame.size.height = Document.minWinSize.height
+            nextFrame.origin.y = nextFrame.origin.y - (Document.minWinSize.height - oldHeight)
         }
 
         return nextFrame

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -89,6 +89,7 @@ class Document: NSDocument {
         }
         
         windowController.window?.setFrame(newFrame, display: true)
+        windowController.window?.minSize = NSSize(width: 200, height: 100)
 
         self.editViewController = windowController.contentViewController as? EditViewController
         editViewController?.document = self


### PR DESCRIPTION
Set a minimum window size so that manually resizing a window can't collapse it all the way, ala:

![xi-before](https://user-images.githubusercontent.com/1210/38568035-3e1da648-3cad-11e8-9090-08f9550c2982.gif)

Most windowed Mac apps keep a small content area displayed at their smallest size. After the change:

![xi-after](https://user-images.githubusercontent.com/1210/38568070-5962058e-3cad-11e8-96f3-d5b45480d189.gif)
