### PR TITLE
Use ~/Library/XiEditor/Log for trace dumps

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -402,7 +402,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         let saveDialog = NSSavePanel.init()
         saveDialog.nameFieldStringValue = "xi-trace-\(pid)"
         if #available(OSX 10.12, *) {
-            saveDialog.directoryURL = FileManager.default.temporaryDirectory
+            saveDialog.directoryURL = errorLogDirectory ?? FileManager.default.temporaryDirectory
         }
         saveDialog.begin { (response) in
             guard response == .OK else { return }


### PR DESCRIPTION
Picked this because we already have the path set up. Currently it defaults to a tmp dir that's hard to find after the fact.