### PR TITLE
Add process/thread name capturing for traces

### DIFF
--- a/XiEditor/Trace.swift
+++ b/XiEditor/Trace.swift
@@ -21,6 +21,22 @@ protocol Writeable {
     func write(_ data: Data)
 }
 
+func gettid() -> UInt64 {
+    var tid : UInt64 = 0
+    pthread_threadid_np(nil, &tid)
+    return tid
+}
+
+func current_thread_name() -> String {
+    let name = Thread.current.name ?? ""
+    if !name.isEmpty {
+        return name
+    }
+
+    let queue_name = __dispatch_queue_get_label(nil);
+    return String(cString: queue_name)
+}
+
 /// Collect trace events so they can be output in Chrome tracing format.
 class Trace {
     let mutex = UnfairLock()
@@ -61,6 +77,8 @@ class Trace {
     }
 
     func trace(_ name: String, _ cat: TraceCategory, _ ph: TracePhase) {
+        let timestamp = mach_absolute_time();
+
         mutex.lock()
         defer {
             mutex.unlock()
@@ -69,12 +87,17 @@ class Trace {
         if !self.enabled {
             return
         }
+
         let i = n_entries % BUF_SIZE
         buf[i].name = name
         buf[i].cat = cat
         buf[i].ph = ph
-        buf[i].abstime = mach_absolute_time()
+        buf[i].abstime = timestamp
+        // TODO: there are cases where this doesn't work as well as pthread_getname_np
+        // but for now it's much simpler.
+        buf[i].thread_name = current_thread_name()
         pthread_threadid_np(nil, &buf[i].tid)
+
         n_entries += 1
     }
 
@@ -85,12 +108,38 @@ class Trace {
         }
 
         var result : [[String: AnyObject]] = []
+        var thread_names_captured = [UInt64: String]()
         
         let pid = getpid()
+
+        result.append([
+            "name": "process_name" as NSString,
+            "ph": "M" as NSString,
+            "pid": NSNumber(value: pid) as AnyObject,
+            "tid": NSNumber(value: buf[0].tid) as AnyObject,
+            "ts": NSNumber(value: gettid()) as AnyObject,
+            "args": ["name": "xi-mac"] as AnyObject])
 
         for entry_num in max(0, n_entries - BUF_SIZE) ..< n_entries {
             let i = entry_num % BUF_SIZE
             let ts = buf[i].abstime * mach_time_numer / mach_time_denom
+
+            let captured_thread_name = thread_names_captured.updateValue(
+                buf[i].thread_name, forKey: buf[i].tid) ?? ""
+
+            if !buf[i].thread_name.isEmpty && captured_thread_name != buf[i].thread_name {
+                let friendly_thread_name = buf[i].thread_name.replacingOccurrences(of: "com.apple.", with: "c.a.")
+                let thread_display_name = "\(buf[i].tid) \(friendly_thread_name)"
+
+                result.append([
+                    "name": "thread_name" as NSString,
+                    "ph": "M" as NSString,
+                    "pid": NSNumber(value: pid) as AnyObject,
+                    "tid": NSNumber(value: buf[i].tid) as AnyObject,
+                    "ts": NSNumber(value: ts) as AnyObject,
+                    "args": ["name": thread_display_name] as AnyObject])
+            }
+
             result.append([
                 "name": buf[i].name as NSString,
                 "cat": buf[i].cat.rawValue as NSString,
@@ -121,13 +170,15 @@ struct TraceEntry {
     var ph: TracePhase
     var abstime: UInt64  // In mach_absolute_time format
     var tid: UInt64
+    var thread_name: String
 
     /// Create a default trace entry, contents don't matter as it's just preallocated
     init() {
         name = ""
         cat = .main
         ph = .instant
-        abstime = mach_absolute_time()
+        abstime = 0
         tid = 0
+        thread_name = ""
     }
 }


### PR DESCRIPTION
Depends on https://github.com/google/xi-editor/pull/588 (which has the screenshot of what the end-to-end work looks like in Chrome trace).