### PR TITLE
Initial implementation of Xi-Mac status bar

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		AED22D841FE84B4B0096E7C3 /* text.f.glsl in Resources */ = {isa = PBXBuildFile; fileRef = AED22D801FE84B4B0096E7C3 /* text.f.glsl */; };
 		AED22D861FE877000096E7C3 /* TextLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED22D851FE877000096E7C3 /* TextLine.swift */; };
 		AED23F181C83CBED002246CE /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED23F171C83CBEC002246CE /* EditView.swift */; };
+		E1288E8020B06E9C0068EEB9 /* StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */; };
 		F53EA2AD1DCAA8110071ACFD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F53EA2AC1DCAA8110071ACFD /* Main.storyboard */; };
 		F53EA2AF1DCAAA170071ACFD /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */; };
 		F5BDBF371DCA9D2C0042430B /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BDBF361DCA9D2C0042430B /* Document.swift */; };
@@ -114,6 +115,7 @@
 		AED22D801FE84B4B0096E7C3 /* text.f.glsl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = text.f.glsl; sourceTree = "<group>"; };
 		AED22D851FE877000096E7C3 /* TextLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLine.swift; sourceTree = "<group>"; };
 		AED23F171C83CBEC002246CE /* EditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
+		E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar.swift; sourceTree = "<group>"; };
 		F53EA2AC1DCAA8110071ACFD /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		F5BDBF361DCA9D2C0042430B /* Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				6B53F5F11EF963EB00A4C664 /* Theme.swift */,
 				6B90DD211F14110B00DF3CE2 /* UserInputPromptController.swift */,
 				28F1ED491EC4C735008839BE /* Search.swift */,
+				E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */,
 				832910D820229C2D0042C32B /* Fps.swift */,
 				AE499DD61C82BB2B002D68AF /* Info.plist */,
 				F53EA2AC1DCAA8110071ACFD /* Main.storyboard */,
@@ -418,6 +421,7 @@
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,
 				6083722F2058597B00E9CF5D /* ShadowView.swift in Sources */,
 				50370A2B1D4209F300EA1B18 /* Dispatcher.swift in Sources */,
+				E1288E8020B06E9C0068EEB9 /* StatusBar.swift in Sources */,
 				AEC4F6CA1FFB02F10060E10E /* Trace.swift in Sources */,
 				6BF9575B1FD70C420010BAE6 /* Client.swift in Sources */,
 				AED23F181C83CBED002246CE /* EditView.swift in Sources */,

--- a/XiEditor.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/XiEditor.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -310,6 +310,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
+    func addStatusItem(viewIdentifier: String, key: String, value: String, alignment: String) {
+        let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
+        DispatchQueue.main.async {
+            let newStatusItem = StatusBarItem(key, value, alignment)
+            document?.editViewController?.statusBar.addSBItem(newStatusItem)
+        }
+    }
+
+    func updateStatusItem(viewIdentifier: String, key: String, value: String) {
+        let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
+        DispatchQueue.main.async {
+            document?.editViewController?.statusBar.updateSBItem(key, value)
+        }
+    }
+
+    func removeStatusItem(viewIdentifier: String, key: String) {
+        let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
+        DispatchQueue.main.async {
+            document?.editViewController?.statusBar.removeSBItem(key)
+        }
+    }
+
     func configChanged(viewIdentifier: ViewIdentifier, changes: [String : AnyObject]) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -313,22 +313,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     func addStatusItem(viewIdentifier: String, key: String, value: String, alignment: String) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
-            let newStatusItem = StatusBarItem(key, value, alignment)
-            document?.editViewController?.statusBar.addSBItem(newStatusItem)
+            let newStatusItem = StatusItem(key, value, alignment)
+            document?.editViewController?.statusBar.addStatusItem(newStatusItem)
         }
     }
 
     func updateStatusItem(viewIdentifier: String, key: String, value: String) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
-            document?.editViewController?.statusBar.updateSBItem(key, value)
+            document?.editViewController?.statusBar.updateStatusItem(key, value)
         }
     }
 
     func removeStatusItem(viewIdentifier: String, key: String) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
-            document?.editViewController?.statusBar.removeSBItem(key)
+            document?.editViewController?.statusBar.removeStatusItem(key)
         }
     }
 

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -54,7 +54,9 @@ protocol XiClient: AnyObject {
     /// A notification containing an alert message to be shown the user.
     func alert(text: String);
 
-    // Status bar notifications
+    /// A list of notifications that manages status items.
+    /// Keys are unique, and alignment (left or right) cannot be
+    /// changed after creating the status item.
     func addStatusItem(viewIdentifier: String, key: String, value: String, alignment: String);
     func updateStatusItem(viewIdentifier: String, key: String, value: String);
     func removeStatusItem(viewIdentifier: String, key: String);

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -54,6 +54,11 @@ protocol XiClient: AnyObject {
     /// A notification containing an alert message to be shown the user.
     func alert(text: String);
 
+    // Status bar notifications
+    func addStatusItem(viewIdentifier: String, key: String, value: String, alignment: String);
+    func updateStatusItem(viewIdentifier: String, key: String, value: String);
+    func removeStatusItem(viewIdentifier: String, key: String);
+
     /// A notification containing changes to the current config for the given view.
     /// - Note: The first time this message is sent, `changes` contains all defined
     // config keys and their values. Subsequent calls contain only those items which

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -313,6 +313,22 @@ class CoreConnection {
         case "alert":
             let message = params["msg"] as! String
             client?.alert(text: message)
+
+        case "add_status_item":
+            let key = params["key"] as! String
+            let value = params["value"] as! String
+            let alignment = params["alignment"] as! String
+            client?.addStatusItem(viewIdentifier: viewIdentifier!, key: key, value: value, alignment: alignment)
+
+        case "update_status_item":
+            let key = params["key"] as! String
+            let value = params["value"] as! String
+            client?.updateStatusItem(viewIdentifier: viewIdentifier!, key: key, value: value)
+
+        case "remove_status_item":
+            let key = params["key"] as! String
+            client?.removeStatusItem(viewIdentifier: viewIdentifier!, key: key)
+
             
         case "find_status":
             let status = params["queries"] as! [[String: AnyObject]]

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -428,7 +428,6 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             return
         }
         let linespace = dataSource.textMetrics.linespace
-        let statusBar = StatusBar()
         let topPad = linespace - dataSource.textMetrics.ascent
         let xOff = dataSource.gutterWidth + x0 - scrollOrigin.x
         let yOff = topPad - scrollOrigin.y

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -564,9 +564,6 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             renderer.drawLine(line: gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
         }
 
-        // status bar drawing
-        statusBar.drawStatusBar(dataSource.gutterWidth, renderer, dirtyRect, dataSource.theme.gutter)
-
         lastRevisionRendered = lineCache.revision
         dataSource.maxWidthChanged(toWidth: maxLineWidth)
         Trace.shared.trace("EditView render", .main, .end)

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -565,7 +565,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         }
 
         // status bar drawing
-        statusBar.drawStatusBar(dataSource.gutterWidth, renderer, dirtyRect)
+        statusBar.drawStatusBar(dataSource.gutterWidth, renderer, dirtyRect, dataSource.theme.gutter)
 
         lastRevisionRendered = lineCache.revision
         dataSource.maxWidthChanged(toWidth: maxLineWidth)

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -428,6 +428,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             return
         }
         let linespace = dataSource.textMetrics.linespace
+        let statusBar = StatusBar()
         let topPad = linespace - dataSource.textMetrics.ascent
         let xOff = dataSource.gutterWidth + x0 - scrollOrigin.x
         let yOff = topPad - scrollOrigin.y
@@ -562,6 +563,10 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
             let y0 = yOff + dataSource.textMetrics.ascent + linespace * CGFloat(lineIx)
             renderer.drawLine(line: gutterTL, x0: GLfloat(x), y0: GLfloat(y0))
         }
+
+        // status bar drawing
+        statusBar.drawStatusBar(dataSource.gutterWidth, renderer, dirtyRect)
+
         lastRevisionRendered = lineCache.revision
         dataSource.maxWidthChanged(toWidth: maxLineWidth)
         Trace.shared.trace("EditView render", .main, .end)

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -145,10 +145,10 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         
                 if color.isDark && unifiedTitlebar {
                     window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
+                    statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
                 } else {
                     window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
                 }
-                statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
             }
         }
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -181,7 +181,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     func setupStatusBar() {
-        statusBar = StatusBar(frame: .zero, backgroundColor: self.theme.background, textColor: self.theme.foreground)
+        if self.unifiedTitlebar == true {
+            statusBar = StatusBar(frame: .zero, backgroundColor: self.theme.background, textColor: self.theme.foreground)
+        } else {
+            statusBar = StatusBar(frame: .zero)
+        }
         self.view.addSubview(statusBar)
 
         NSLayoutConstraint.activate([
@@ -213,8 +217,8 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     @objc func frameDidChangeNotification(_ notification: Notification) {
         updateEditViewHeight()
-        statusBar.updateItemVisibility(windowWidth: self.editViewWidth.constant)
         willScroll(to: scrollView.contentView.bounds.origin)
+        statusBar.updateItemVisibility(windowWidth: self.view.frame.width)
         updateViewportSize()
     }
 
@@ -247,7 +251,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         updateViewportSize()
         editView.gutterCache = nil
         shadowView.updateShadowColor(newColor: theme.shadow)
-        statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
+        if self.unifiedTitlebar == true {
+            statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
+        }
         editView.needsDisplay = true
 
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -180,10 +180,16 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
         if #available(OSX 10.12, *) {
             let testLabelLeft = NSTextField(labelWithString: "Xi-Mac")
+            let anotherLeft = NSTextField(labelWithString: "Xi-Mac")
+
             let testLabelRight = NSTextField(labelWithString: "Status Bar")
+            let anotherRight = NSTextField(labelWithString: "Status Bar")
+
 
             statusBar.addSBItem(testLabelLeft, alignment: .left)
+            statusBar.addSBItem(anotherLeft, alignment: .left)
             statusBar.addSBItem(testLabelRight, alignment: .right)
+            statusBar.addSBItem(anotherRight, alignment: .right)
         }
 
         shadowView.setup()

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -213,6 +213,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     @objc func frameDidChangeNotification(_ notification: Notification) {
         updateEditViewHeight()
+        statusBar.updateItemVisibility(windowWidth: self.editViewWidth.constant)
         willScroll(to: scrollView.contentView.bounds.origin)
         updateViewportSize()
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -157,6 +157,8 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     private var dragTimer: Timer?
     private var dragEvent: NSEvent?
 
+    var statusBar: StatusBar!
+
     override func viewDidLoad() {
         super.viewDidLoad()
         shadowView.wantsLayer = true
@@ -166,10 +168,16 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         scrollView.hasHorizontalScroller = true
         scrollView.usesPredominantAxisScrolling = true
         (scrollView.contentView as? XiClipView)?.delegate = self
+
     }
 
     override func viewDidAppear() {
         super.viewDidAppear()
+
+        statusBar = StatusBar(frame: self.view.frame)
+        self.view.addSubview(statusBar)
+        statusBar.setup(editView)
+
         shadowView.setup()
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSView.frameDidChangeNotification, object: scrollView)
         // call to set initial scroll position once we know view size

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -180,21 +180,10 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
         if #available(OSX 10.12, *) {
             let testLabelLeft = NSTextField(labelWithString: "Xi-Mac")
-            testLabelLeft.textColor = NSColor.black
-
             let testLabelRight = NSTextField(labelWithString: "Status Bar")
-            testLabelRight.textColor = NSColor.black
-            testLabelRight.alignment = .right
 
-            statusBar.addSubview(testLabelLeft)
-            statusBar.addSubview(testLabelRight)
-
-            testLabelLeft.translatesAutoresizingMaskIntoConstraints = false
-            testLabelRight.translatesAutoresizingMaskIntoConstraints = false
-
-            testLabelLeft.leadingAnchor.constraint(equalTo: statusBar.leadingAnchor).isActive = true
-            testLabelRight.trailingAnchor.constraint(equalTo: statusBar.trailingAnchor).isActive = true
-
+            statusBar.addSBItem(testLabelLeft, alignment: .left)
+            statusBar.addSBItem(testLabelRight, alignment: .right)
         }
 
         shadowView.setup()

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -173,14 +173,24 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     override func viewDidAppear() {
         super.viewDidAppear()
-
-        statusBar = StatusBar(frame: self.view.frame)
-        self.view.addSubview(statusBar)
-        statusBar.setup(editView)
+        setupStatusBar()
         shadowView.setup()
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSView.frameDidChangeNotification, object: scrollView)
         // call to set initial scroll position once we know view size
         redrawEverything()
+    }
+
+    func setupStatusBar() {
+        statusBar = StatusBar(frame: .zero, backgroundColor: self.theme.background, textColor: self.theme.foreground)
+        self.view.addSubview(statusBar)
+
+        NSLayoutConstraint.activate([
+            statusBar.heightAnchor.constraint(equalToConstant: statusBar.statusBarHeight),
+            statusBar.widthAnchor.constraint(equalTo: editView.widthAnchor),
+            statusBar.leadingAnchor.constraint(equalTo: editView.leadingAnchor),
+            statusBar.trailingAnchor.constraint(equalTo: editView.trailingAnchor),
+            statusBar.bottomAnchor.constraint(equalTo: editView.bottomAnchor)
+            ])
     }
 
     func updateGutterWidth() {
@@ -236,6 +246,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         updateViewportSize()
         editView.gutterCache = nil
         shadowView.updateShadowColor(newColor: theme.shadow)
+        statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
         editView.needsDisplay = true
 
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -159,7 +159,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     private var dragTimer: Timer?
     private var dragEvent: NSEvent?
 
-    var statusBar: StatusBar!
+    let statusBar = StatusBar(frame: .zero)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -183,7 +183,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     func setupStatusBar() {
-        statusBar = StatusBar(frame: .zero)
         statusBar.hasUnifiedTitlebar = unifiedTitlebar
         self.view.addSubview(statusBar)
 

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -215,8 +215,8 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     @objc func frameDidChangeNotification(_ notification: Notification) {
         updateEditViewHeight()
         willScroll(to: scrollView.contentView.bounds.origin)
-        statusBar.updateItemVisibility(windowWidth: self.view.frame.width)
         updateViewportSize()
+        statusBar.checkItemsFitFor(windowWidth: self.view.frame.width)
     }
 
     /// Called by `XiClipView`; this gives us early notice of an incoming scroll event.

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -177,22 +177,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         statusBar = StatusBar(frame: self.view.frame)
         self.view.addSubview(statusBar)
         statusBar.setup(editView)
-
-        if #available(OSX 10.12, *) {
-            let testLabelLeft = NSTextField(labelWithString: "Xi-Mac")
-            let anotherLeft = NSTextField(labelWithString: "Xi-Mac")
-
-            let testLabelRight = NSTextField(labelWithString: "Status Bar 1")
-            let anotherRight = NSTextField(labelWithString: "Status Bar 2")
-
-//
-//            statusBar.addSBItem(testLabelLeft, alignment: .left)
-//            statusBar.addSBItem(anotherLeft, alignment: .left)
-//            statusBar.addSBItem(testLabelRight, alignment: .right)
-//            statusBar.addSBItem(anotherRight, alignment: .right)
-//            statusBar.removeSBItem()
-        }
-
         shadowView.setup()
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSView.frameDidChangeNotification, object: scrollView)
         // call to set initial scroll position once we know view size

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -148,6 +148,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
                 } else {
                     window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
                 }
+                statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
             }
         }
     }
@@ -181,11 +182,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     func setupStatusBar() {
-        if self.unifiedTitlebar == true {
-            statusBar = StatusBar(frame: .zero, backgroundColor: self.theme.background, textColor: self.theme.foreground)
-        } else {
-            statusBar = StatusBar(frame: .zero)
-        }
+        statusBar = StatusBar(frame: .zero)
         self.view.addSubview(statusBar)
 
         NSLayoutConstraint.activate([
@@ -251,9 +248,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         updateViewportSize()
         editView.gutterCache = nil
         shadowView.updateShadowColor(newColor: theme.shadow)
-        if self.unifiedTitlebar == true {
-            statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
-        }
         editView.needsDisplay = true
 
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -142,10 +142,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         
                 window.titlebarAppearsTransparent = unifiedTitlebar
                 window.backgroundColor = unifiedTitlebar ? color : nil
-        
+
+                statusBar.updateStatusBarColor(newBackgroundColor: self.theme.background, newTextColor: self.theme.foreground, newUnifiedTitlebar: unifiedTitlebar)
+
                 if color.isDark && unifiedTitlebar {
                     window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
-                    statusBar.updateStatusBarColor(newBackgroundColor: theme.background, newTextColor: theme.foreground)
                 } else {
                     window.appearance = NSAppearance(named: NSAppearance.Name.aqua)
                 }
@@ -183,6 +184,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     func setupStatusBar() {
         statusBar = StatusBar(frame: .zero)
+        statusBar.hasUnifiedTitlebar = unifiedTitlebar
         self.view.addSubview(statusBar)
 
         NSLayoutConstraint.activate([

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -189,7 +189,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
         NSLayoutConstraint.activate([
             statusBar.heightAnchor.constraint(equalToConstant: statusBar.statusBarHeight),
-            statusBar.widthAnchor.constraint(equalTo: editView.widthAnchor),
             statusBar.leadingAnchor.constraint(equalTo: editView.leadingAnchor),
             statusBar.trailingAnchor.constraint(equalTo: editView.trailingAnchor),
             statusBar.bottomAnchor.constraint(equalTo: editView.bottomAnchor)

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -185,12 +185,12 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
             let testLabelRight = NSTextField(labelWithString: "Status Bar 1")
             let anotherRight = NSTextField(labelWithString: "Status Bar 2")
 
-
-            statusBar.addSBItem(testLabelLeft, alignment: .left)
-            statusBar.addSBItem(anotherLeft, alignment: .left)
-            statusBar.addSBItem(testLabelRight, alignment: .right)
-            statusBar.addSBItem(anotherRight, alignment: .right)
-            statusBar.removeSBItem()
+//
+//            statusBar.addSBItem(testLabelLeft, alignment: .left)
+//            statusBar.addSBItem(anotherLeft, alignment: .left)
+//            statusBar.addSBItem(testLabelRight, alignment: .right)
+//            statusBar.addSBItem(anotherRight, alignment: .right)
+//            statusBar.removeSBItem()
         }
 
         shadowView.setup()

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -178,6 +178,25 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         self.view.addSubview(statusBar)
         statusBar.setup(editView)
 
+        if #available(OSX 10.12, *) {
+            let testLabelLeft = NSTextField(labelWithString: "Xi-Mac")
+            testLabelLeft.textColor = NSColor.black
+
+            let testLabelRight = NSTextField(labelWithString: "Status Bar")
+            testLabelRight.textColor = NSColor.black
+            testLabelRight.alignment = .right
+
+            statusBar.addSubview(testLabelLeft)
+            statusBar.addSubview(testLabelRight)
+
+            testLabelLeft.translatesAutoresizingMaskIntoConstraints = false
+            testLabelRight.translatesAutoresizingMaskIntoConstraints = false
+
+            testLabelLeft.leadingAnchor.constraint(equalTo: statusBar.leadingAnchor).isActive = true
+            testLabelRight.trailingAnchor.constraint(equalTo: statusBar.trailingAnchor).isActive = true
+
+        }
+
         shadowView.setup()
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSView.frameDidChangeNotification, object: scrollView)
         // call to set initial scroll position once we know view size

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -182,14 +182,15 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
             let testLabelLeft = NSTextField(labelWithString: "Xi-Mac")
             let anotherLeft = NSTextField(labelWithString: "Xi-Mac")
 
-            let testLabelRight = NSTextField(labelWithString: "Status Bar")
-            let anotherRight = NSTextField(labelWithString: "Status Bar")
+            let testLabelRight = NSTextField(labelWithString: "Status Bar 1")
+            let anotherRight = NSTextField(labelWithString: "Status Bar 2")
 
 
             statusBar.addSBItem(testLabelLeft, alignment: .left)
             statusBar.addSBItem(anotherLeft, alignment: .left)
             statusBar.addSBItem(testLabelRight, alignment: .right)
             statusBar.addSBItem(anotherRight, alignment: .right)
+            statusBar.removeSBItem()
         }
 
         shadowView.setup()

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -230,6 +230,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         editView.gutterCache = nil
         shadowView.updateShadowColor(newColor: theme.shadow)
         editView.needsDisplay = true
+
     }
 
     fileprivate func updateEditViewHeight() {

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -66,7 +66,7 @@ class StatusBar: NSView {
 
     var backgroundColor: NSColor = NSColor.white
     var itemTextColor: NSColor = NSColor.black
-    var statusBarPadding: CGFloat = 10
+    let statusBarPadding: CGFloat = 10
     let statusBarHeight: CGFloat = 20
 
     // Returns the minimum width required to display all items.
@@ -102,6 +102,7 @@ class StatusBar: NSView {
         item.textColor = itemTextColor
         self.addSubview(item)
         currentItems[item.key] = item
+        updateItemVisibility(windowWidth: self.superview!.frame.width)
         self.needsUpdateConstraints = true
     }
 
@@ -182,14 +183,14 @@ class StatusBar: NSView {
                     guard lastLeftItem != nil else { return }
                     lastLeftItem!.isHidden = true
                     currentItems.removeValue(forKey: lastLeftItem!.key)
-                    lastLeftItem = leftItems[leftItems.count - 1]
                     hiddenItems.append(lastLeftItem!)
+                    lastLeftItem = leftItems[leftItems.count - 1]
                 } else {
                     guard lastRightItem != nil else { return }
                     lastRightItem!.isHidden = true
                     currentItems.removeValue(forKey: lastRightItem!.key)
-                    lastRightItem = rightItems[rightItems.count - 1]
                     hiddenItems.append(lastRightItem!)
+                    lastRightItem = rightItems[rightItems.count - 1]
                 }
             } while (windowWidth < minWidth)
         } else {
@@ -203,7 +204,8 @@ class StatusBar: NSView {
                     case .right:
                         lastRightItem = lastHiddenItem
                     }
-                    currentItems.updateValue(lastHiddenItem, forKey: lastHiddenItem.key)
+                    currentItems[lastHiddenItem.key] = lastHiddenItem
+                    self.needsUpdateConstraints = true
                     hiddenItems.removeLast()
                 }
             }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -14,7 +14,30 @@ class StatusBar: NSView {
     private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
     private let statusBarHeight: CGFloat = 30
 
-    func drawStatusBar(_ gutterWidth: CGFloat, _ renderer: Renderer, _ dirtyRect: NSRect, _ statusBarColor: NSColor) {
-        renderer.drawSolidRect(x: GLfloat(gutterWidth), y: GLfloat(dirtyRect.height - statusBarHeight), width: GLfloat(dirtyRect.width), height: GLfloat(statusBarHeight), argb: colorToArgb(statusBarColor))
+    override var isFlipped: Bool {
+        return true;
+    }
+
+    func setup(_ editView: NSView) {
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        self.heightAnchor.constraint(equalToConstant: statusBarHeight).isActive = true
+        self.widthAnchor.constraint(equalTo: editView.widthAnchor).isActive = true
+
+        self.leadingAnchor.constraint(equalTo: editView.leadingAnchor).isActive = true
+        self.trailingAnchor.constraint(equalTo: editView.trailingAnchor).isActive = true
+        self.bottomAnchor.constraint(equalTo: editView.bottomAnchor).isActive = true
+
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        let path = NSBezierPath()
+        backgroundColor.setFill()
+        __NSRectFill(dirtyRect)
+        path.move(to: CGPoint(x: dirtyRect.maxX, y: dirtyRect.minY))
+        path.line(to: CGPoint(x: dirtyRect.minX, y: dirtyRect.minY))
     }
 }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -39,6 +39,7 @@ class StatusItem: NSTextField {
         self.lineBreakMode = .byClipping
         self.isBezeled = false
         self.stringValue = value
+        self.preferredMaxLayoutWidth = self.frame.width
     }
 
     required init?(coder: NSCoder) {
@@ -76,8 +77,8 @@ class StatusBar: NSView {
             .reduce(CGFloat(currentItems.count - 1) * statusBarPadding, +)
     }
 
-    // Difference to compensate for when status bar is resized
-    let minWidthDifference: CGFloat = 2
+    // Difference (in points) to compensate for when status bar is resized
+    let minWidthDifference: CGFloat = 3
 
     override var isFlipped: Bool {
         return true;
@@ -110,8 +111,10 @@ class StatusBar: NSView {
     func updateStatusItem(_ key: String, _ value: String) {
         if let item = currentItems[key] {
             item.stringValue = value
+            currentItems.updateValue(item, forKey: key)
         } else if let item = hiddenItems.first(where: {$0.key == key}) {
             item.stringValue = value
+            currentItems.updateValue(item, forKey: key)
         } else {
             print("tried to update item with key \(key) that doesn't exist")
         }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -69,6 +69,13 @@ class StatusBar: NSView {
         }
     }
 
+    func removeSBItem() {
+        if let item = rightItems.last {
+            item.removeFromSuperview()
+            rightItems.removeLast()
+        }
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
 

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -79,27 +79,13 @@ class StatusBar: NSView {
         item.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
         currentItems[item.key] = item
 
+        switch item.barAlignment {
+            case .left:
+                leftItems.append(item)
+            case .right:
+                rightItems.append(item)
+        }
         self.needsUpdateConstraints = true
-
-//        switch item.barAlignment {
-//        case .left:
-//            // instead of checking left and right arrays, we can just iterate through the dictionary and check if a left/right item exists
-//            if let lastLeftItem = self.leftItems.last {
-//                item.leadingAnchor.constraint(equalTo: lastLeftItem.trailingAnchor, constant: 10).isActive = true
-//            } else {
-//                item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
-//            }
-//            leftItems.append(item)
-//
-//        case .right:
-//            if let lastRightItem = self.rightItems.last {
-//                item.trailingAnchor.constraint(equalTo: lastRightItem.leadingAnchor, constant: 10).isActive = true
-//            } else {
-//                item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
-//            }
-//            rightItems.append(item)
-//        }
-
     }
 
     // Update a status bar item with a new value.
@@ -124,19 +110,19 @@ class StatusBar: NSView {
     // Called when the status bar item state is modified.
     override func updateConstraints() {
         for item in currentItems.values {
-            if item.alignment == .left {
+            if item.barAlignment == .left {
                 if item == leftItems.first {
-                    item.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 10).isActive = true
+                    item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
                 } else {
                     item.leadingAnchor.constraint(equalTo:
-                        leftItems[leftItems.index(of: item)! - 1].leadingAnchor, constant: 10).isActive = true
+                        leftItems[leftItems.index(of: item)! - 1].trailingAnchor, constant: 10).isActive = true
                 }
             } else {
                 if item == rightItems.first {
-                    item.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 10).isActive = true
+                    item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
                 } else {
                     item.trailingAnchor.constraint(equalTo:
-                        rightItems[rightItems.index(of: item)! + 1].trailingAnchor, constant: 10).isActive = true
+                        rightItems[rightItems.index(of: item)! - 1].leadingAnchor, constant: -10).isActive = true
                 }
             }
         }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -72,28 +72,34 @@ class StatusBar: NSView {
             updateStatusItem(existingItem.key, item.value)
             return
         }
+        print("added item \(item.key)")
         item.translatesAutoresizingMaskIntoConstraints = false
         item.textColor = NSColor.black
         self.addSubview(item)
         item.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+        currentItems[item.key] = item
 
-        switch item.barAlignment {
-        case .left:
-            if let lastLeftItem = self.leftItems.last {
-                item.leadingAnchor.constraint(equalTo: lastLeftItem.trailingAnchor, constant: 10).isActive = true
-            } else {
-                item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
-            }
-            leftItems.append(item)
+        self.needsUpdateConstraints = true
 
-        case .right:
-            if let lastRightItem = self.rightItems.last {
-                item.trailingAnchor.constraint(equalTo: lastRightItem.leadingAnchor, constant: 10).isActive = true
-            } else {
-                item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
-            }
-            rightItems.append(item)
-        }
+//        switch item.barAlignment {
+//        case .left:
+//            // instead of checking left and right arrays, we can just iterate through the dictionary and check if a left/right item exists
+//            if let lastLeftItem = self.leftItems.last {
+//                item.leadingAnchor.constraint(equalTo: lastLeftItem.trailingAnchor, constant: 10).isActive = true
+//            } else {
+//                item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+//            }
+//            leftItems.append(item)
+//
+//        case .right:
+//            if let lastRightItem = self.rightItems.last {
+//                item.trailingAnchor.constraint(equalTo: lastRightItem.leadingAnchor, constant: 10).isActive = true
+//            } else {
+//                item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+//            }
+//            rightItems.append(item)
+//        }
+
     }
 
     // Update a status bar item with a new value.
@@ -120,17 +126,17 @@ class StatusBar: NSView {
         for item in currentItems.values {
             if item.alignment == .left {
                 if item == leftItems.first {
-                    item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+                    item.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 10).isActive = true
                 } else {
                     item.leadingAnchor.constraint(equalTo:
-                        leftItems[leftItems.index(of: item)! - 1].leadingAnchor).isActive = true
+                        leftItems[leftItems.index(of: item)! - 1].leadingAnchor, constant: 10).isActive = true
                 }
             } else {
                 if item == rightItems.first {
-                    item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+                    item.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 10).isActive = true
                 } else {
                     item.trailingAnchor.constraint(equalTo:
-                        rightItems[rightItems.index(of: item)! + 1].trailingAnchor).isActive = true
+                        rightItems[rightItems.index(of: item)! + 1].trailingAnchor, constant: 10).isActive = true
                 }
             }
         }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -11,6 +11,11 @@ import Cocoa
 
 class StatusBar: NSView {
 
+    enum StatusItemAlignment {
+        case left
+        case right
+    }
+
     private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
     private let statusBarHeight: CGFloat = 20
 
@@ -29,6 +34,23 @@ class StatusBar: NSView {
         self.trailingAnchor.constraint(equalTo: editView.trailingAnchor).isActive = true
         self.bottomAnchor.constraint(equalTo: editView.bottomAnchor).isActive = true
 
+    }
+
+    func addSBItem(_ item: NSTextField, alignment: StatusItemAlignment) {
+        item.translatesAutoresizingMaskIntoConstraints = false
+        item.textColor = NSColor.black
+
+        self.addSubview(item)
+
+        switch alignment {
+        case .left:
+            item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+
+        case .right:
+            item.alignment = .right
+            item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+
+        }
     }
 
     override func draw(_ dirtyRect: NSRect) {

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -82,11 +82,12 @@ class StatusBar: NSView {
     // Difference (in points) to compensate for when status bar is resized
     let minWidthDifference: CGFloat = 3
 
-    // Returns the minimum width required to display all items.
+    // Returns the minimum width required to display items without
+    // clipping in the status bar.
     var minWidth: CGFloat {
         return currentItems.values.filter { $0.isHidden == false }
             .map({$0.bounds.width})
-            .reduce(CGFloat(currentItems.count - 1) * statusBarPadding, +)
+            .reduce(CGFloat(currentItems.count - hiddenItems.count - 1) * statusBarPadding, +)
     }
 
     override var isFlipped: Bool {
@@ -142,6 +143,8 @@ class StatusBar: NSView {
 
     // Also handles ordering of status bar items.
     // Called when the status bar item state is modified.
+    // First checks if item being modified belongs to the left or the right,
+    // then adds constraints as necessary.
     override func updateConstraints() {
         lastLeftItem = leftItems.first
         lastRightItem = rightItems.first
@@ -149,6 +152,7 @@ class StatusBar: NSView {
         for item in currentItems.values.sorted(by: {$0.key < $1.key}) {
             NSLayoutConstraint.deactivate(item.barConstraints)
             item.barConstraints.removeAll()
+            item.sizeToFit()
             switch item.barAlignment {
             case .left:
                 if item == leftItems.first {
@@ -193,7 +197,7 @@ class StatusBar: NSView {
             }
         } else {
             self.backgroundColor = NSColor.windowBackgroundColor
-            self.borderColor = NSColor.windowFrameColor
+            self.borderColor = NSColor.systemGray
             for item in currentItems.values {
                 item.textColor = NSColor.labelColor
             }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -70,11 +70,17 @@ class StatusBar: NSView {
     var lastLeftItem: StatusItem?
     var lastRightItem: StatusItem?
 
-    var backgroundColor: NSColor = NSColor.windowFrameColor
-    var itemTextColor: NSColor = NSColor.windowFrameTextColor
+    var hasUnifiedTitlebar: Bool?
+
+    var backgroundColor: NSColor = NSColor.windowBackgroundColor
+    var itemTextColor: NSColor = NSColor.labelColor
+    var borderColor: NSColor = NSColor.windowFrameColor
     let statusBarPadding: CGFloat = 10
     let statusBarHeight: CGFloat = 24
     let firstItemMargin: CGFloat = 3
+
+    // Difference (in points) to compensate for when status bar is resized
+    let minWidthDifference: CGFloat = 3
 
     // Returns the minimum width required to display all items.
     var minWidth: CGFloat {
@@ -82,9 +88,6 @@ class StatusBar: NSView {
             .map({$0.frame.width})
             .reduce(CGFloat(currentItems.count - 1) * statusBarPadding, +)
     }
-
-    // Difference (in points) to compensate for when status bar is resized
-    let minWidthDifference: CGFloat = 3
 
     override var isFlipped: Bool {
         return true;
@@ -178,9 +181,23 @@ class StatusBar: NSView {
         super.updateConstraints()
     }
 
-    func updateStatusBarColor(newBackgroundColor: NSColor, newTextColor: NSColor) {
-        self.backgroundColor = newBackgroundColor
-        self.itemTextColor = newTextColor
+    func updateStatusBarColor(newBackgroundColor: NSColor, newTextColor: NSColor, newUnifiedTitlebar: Bool) {
+        self.hasUnifiedTitlebar = newUnifiedTitlebar
+
+        if self.hasUnifiedTitlebar! {
+            self.backgroundColor = newBackgroundColor
+            self.borderColor = newBackgroundColor
+            self.itemTextColor = NSColor.labelColor
+            for item in currentItems.values {
+                item.textColor = self.itemTextColor
+            }
+        } else {
+            self.backgroundColor = NSColor.windowBackgroundColor
+            self.borderColor = NSColor.windowFrameColor
+            for item in currentItems.values {
+                item.textColor = NSColor.labelColor
+            }
+        }
         self.needsDisplay = true
     }
 
@@ -227,17 +244,10 @@ class StatusBar: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-//        backgroundColor.setFill()
+
+        backgroundColor.setFill()
         dirtyRect.fill()
-
-        // test to replicate native NSWindow title gradient
-        let native1 = NSColor(calibratedWhite: 246/255, alpha: 1)
-        let native2 = NSColor(calibratedWhite: 202/255, alpha: 1)
-        let nativeColor = NSGradient(colors: [native1, native2])
-
-        nativeColor?.draw(in: dirtyRect, angle: 90)
-
-        let borderColor = NSColor(calibratedRed: 194 / 255, green: 194 / 255, blue: 194 / 255, alpha: 1)
+        borderColor = backgroundColor
         borderColor.setStroke()
 
         let path = NSBezierPath()
@@ -246,4 +256,5 @@ class StatusBar: NSView {
         path.line(to: CGPoint(x: dirtyRect.maxX, y: dirtyRect.minY))
         path.stroke()
     }
+
 }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -49,18 +49,25 @@ class StatusItem: NSTextField {
 
 class StatusBar: NSView {
 
+    var currentItems = [String : StatusItem]()
+    var hiddenItems = [StatusItem]()
+    var leftItems = [StatusItem]()
+    var rightItems = [StatusItem]()
+
     var backgroundColor: NSColor
     var itemTextColor: NSColor
     var statusBarPadding: CGFloat = 10
     let statusBarHeight: CGFloat = 20
 
-    var leftItems = [StatusItem]()
-    var rightItems = [StatusItem]()
-
     var lastLeftItem: StatusItem?
     var lastRightItem: StatusItem?
-    
-    var currentItems = [String : StatusItem]()
+
+    // Returns the minimum width required to display all items.
+    var minWidth: CGFloat {
+        return currentItems.values
+            .map({$0.frame.width})
+            .reduce(CGFloat(currentItems.count - 1) * statusBarPadding, +)
+    }
 
     override var isFlipped: Bool {
         return true;
@@ -170,6 +177,24 @@ class StatusBar: NSView {
         self.backgroundColor = newBackgroundColor
         self.itemTextColor = newTextColor
         self.needsDisplay = true
+    }
+
+    func updateItemVisibility(windowWidth: CGFloat) {
+        if windowWidth < minWidth {
+            repeat {
+                if leftItems.count > rightItems.count {
+                    guard lastLeftItem != nil else { return }
+                    lastLeftItem!.isHidden = true
+                    hiddenItems.append(lastLeftItem!)
+                } else {
+                    guard lastRightItem != nil else { return }
+                    lastRightItem!.isHidden = true
+                    hiddenItems.append(lastRightItem!)
+                }
+            } while (windowWidth < minWidth)
+        } else {
+            hiddenItems.popLast()?.isHidden = false
+        }
     }
 
     override func draw(_ dirtyRect: NSRect) {

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -87,7 +87,7 @@ class StatusBar: NSView {
     var minWidth: CGFloat {
         return currentItems.values.filter { $0.isHidden == false }
             .map({$0.bounds.width})
-            .reduce(CGFloat(currentItems.count - hiddenItems.count - 1) * statusBarPadding, +)
+            .reduce(CGFloat((currentItems.count - hiddenItems.count) - 1) * statusBarPadding, +)
     }
 
     override var isFlipped: Bool {
@@ -114,7 +114,7 @@ class StatusBar: NSView {
         self.addSubview(item)
         currentItems[item.key] = item
         self.needsUpdateConstraints = true
-        checkItemsFitFor(windowWidth: self.superview!.frame.width)
+        checkItemsFitFor(windowWidth: self.bounds.width)
     }
 
     // Update a status bar item with a new value.
@@ -122,7 +122,7 @@ class StatusBar: NSView {
         if let item = currentItems[key] {
             item.stringValue = value
             currentItems.updateValue(item, forKey: key)
-            checkItemsFitFor(windowWidth: self.superview!.frame.width)
+            checkItemsFitFor(windowWidth: self.bounds.width)
         } else {
             print("tried to update item with key \(key) that doesn't exist")
         }
@@ -134,7 +134,7 @@ class StatusBar: NSView {
             item.removeFromSuperview()
             currentItems.removeValue(forKey: key)
             self.needsUpdateConstraints = true
-            checkItemsFitFor(windowWidth: self.superview!.frame.width)
+            checkItemsFitFor(windowWidth: self.bounds.width)
         } else {
             print("tried to remove item with \(key) that doesn't exist")
             return

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -12,7 +12,7 @@ import Cocoa
 class StatusBar: NSView {
 
     private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
-    private let statusBarHeight: CGFloat = 30
+    private let statusBarHeight: CGFloat = 20
 
     override var isFlipped: Bool {
         return true;

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -118,9 +118,6 @@ class StatusBar: NSView {
         if let item = currentItems[key] {
             item.stringValue = value
             currentItems.updateValue(item, forKey: key)
-        } else if let item = hiddenItems.first(where: {$0.key == key}) {
-            item.stringValue = value
-            currentItems.updateValue(item, forKey: key)
         } else {
             print("tried to update item with key \(key) that doesn't exist")
         }
@@ -130,9 +127,6 @@ class StatusBar: NSView {
     // Removes status bar item with a specified key.
     func removeStatusItem(_ key: String) {
         if let item = currentItems[key] {
-            item.removeFromSuperview()
-            currentItems.removeValue(forKey: key)
-        } else if let item = hiddenItems.first(where: {$0.key == key}) {
             item.removeFromSuperview()
             currentItems.removeValue(forKey: key)
         } else {

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -88,13 +88,6 @@ class StatusBar: NSView {
         self.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    init(frame frameRect: NSRect, backgroundColor: NSColor, textColor: NSColor) {
-        self.backgroundColor = backgroundColor
-        self.itemTextColor = textColor
-        super.init(frame: .zero)
-        self.translatesAutoresizingMaskIntoConstraints = false
-    }
-
     required init?(coder decoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -70,8 +70,8 @@ class StatusBar: NSView {
     var lastLeftItem: StatusItem?
     var lastRightItem: StatusItem?
 
-    var backgroundColor: NSColor = NSColor.textBackgroundColor
-    var itemTextColor: NSColor = NSColor.textColor
+    var backgroundColor: NSColor = NSColor.windowFrameColor
+    var itemTextColor: NSColor = NSColor.windowFrameTextColor
     let statusBarPadding: CGFloat = 10
     let statusBarHeight: CGFloat = 24
     let firstItemMargin: CGFloat = 3
@@ -233,17 +233,23 @@ class StatusBar: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-        backgroundColor.setFill()
+//        backgroundColor.setFill()
         dirtyRect.fill()
 
-        let borderColor = NSColor.systemGray
+        // test to replicate native NSWindow title gradient
+        let native1 = NSColor(calibratedWhite: 246/255, alpha: 1)
+        let native2 = NSColor(calibratedWhite: 202/255, alpha: 1)
+        let nativeColor = NSGradient(colors: [native1, native2])
+
+        nativeColor?.draw(in: dirtyRect, angle: 90)
+
+        let borderColor = NSColor(calibratedRed: 194 / 255, green: 194 / 255, blue: 194 / 255, alpha: 1)
         borderColor.setStroke()
 
         let path = NSBezierPath()
-        path.lineWidth = 0
+        path.lineWidth = 1
         path.move(to: CGPoint(x: dirtyRect.minX, y: dirtyRect.minY))
         path.line(to: CGPoint(x: dirtyRect.maxX, y: dirtyRect.minY))
         path.stroke()
-
     }
 }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -19,6 +19,9 @@ class StatusBar: NSView {
     private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
     private let statusBarHeight: CGFloat = 20
 
+    var leftItems = [NSTextField]()
+    var rightItems = [NSTextField]()
+
     override var isFlipped: Bool {
         return true;
     }
@@ -41,15 +44,28 @@ class StatusBar: NSView {
         item.textColor = NSColor.black
 
         self.addSubview(item)
+        item.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
 
         switch alignment {
         case .left:
-            item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            if let lastLeftItem = self.leftItems.last {
+                item.leadingAnchor.constraint(equalTo: lastLeftItem.trailingAnchor, constant: 10).isActive = true
+
+
+            } else {
+                item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            }
+            leftItems.append(item)
 
         case .right:
             item.alignment = .right
-            item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
 
+            if let lastRightItem = self.rightItems.last {
+                item.trailingAnchor.constraint(equalTo: lastRightItem.leadingAnchor, constant: 10).isActive = true
+            } else {
+                item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+            }
+            rightItems.append(item)
         }
     }
 

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -54,7 +54,6 @@ class StatusBar: NSView {
     var statusBarPadding: CGFloat = 10
     let statusBarHeight: CGFloat = 20
 
-    // This should change in the future, as ordering is alphabetical.
     var leftItems = [StatusItem]()
     var rightItems = [StatusItem]()
 
@@ -122,20 +121,27 @@ class StatusBar: NSView {
     }
 
     // Update constraints of status bar items.
+    // Also handles ordering of status bar items.
     // Called when the status bar item state is modified.
     override func updateConstraints() {
         lastLeftItem = leftItems.first
         lastRightItem = rightItems.first
 
+        leftItems = leftItems.sorted(by: {$0.key < $1.key})
+        rightItems = rightItems.sorted(by: {$0.key < $1.key})
+
         for item in currentItems.values.sorted(by: {$0.key < $1.key}) {
+            item.removeFromSuperview()
             switch item.barAlignment {
             case .left:
                 if item == leftItems.first {
+                    self.addSubview(item)
                     item.leadingAnchor.constraint(equalTo:
                         self.leadingAnchor)
                         .isActive = true
                 } else {
                     guard lastLeftItem != nil else { return }
+                    self.addSubview(item)
                     item.leadingAnchor.constraint(equalTo:
                         lastLeftItem!.trailingAnchor, constant: statusBarPadding)
                         .isActive = true
@@ -143,11 +149,13 @@ class StatusBar: NSView {
                 }
             case .right:
                 if item == rightItems.first {
+                    self.addSubview(item)
                     item.trailingAnchor.constraint(equalTo:
                         self.trailingAnchor)
                         .isActive = true
                 } else {
                     guard lastRightItem != nil else { return }
+                    self.addSubview(item)
                     item.trailingAnchor.constraint(equalTo:
                         lastRightItem!.leadingAnchor, constant: -statusBarPadding)
                         .isActive = true

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -1,0 +1,20 @@
+//
+//  StatusBar.swift
+//  XiEditor
+//
+//  Created by Dzũng Lê on 19/05/2018.
+//  Copyright © 2018 Raph Levien. All rights reserved.
+//
+
+import Foundation
+import Cocoa
+
+class StatusBar: NSView {
+
+    private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
+    private let statusBarHeight: CGFloat = 15
+
+    func drawStatusBar(_ gutterWidth: CGFloat, _ renderer: Renderer, _ dirtyRect: NSRect) {
+        renderer.drawSolidRect(x: GLfloat(gutterWidth), y: GLfloat(dirtyRect.height - statusBarHeight), width: GLfloat(dirtyRect.width), height: GLfloat(statusBarHeight), argb: colorToArgb(NSColor.white))
+    }
+}

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -14,7 +14,7 @@ enum StatusItemAlignment: String {
     case right = "right"
 }
 
-class StatusBarItem: NSTextField {
+class StatusItem: NSTextField {
 
     var key: String = ""
     var value: String = ""
@@ -26,6 +26,7 @@ class StatusBarItem: NSTextField {
         self.barAlignment = StatusItemAlignment(rawValue: barAlignment)!
         super.init(frame: NSZeroRect)
 
+        // Similar to what NSTextField convenience init creates
         self.isEditable = false
         self.isSelectable = false
         self.textColor = NSColor.labelColor
@@ -45,30 +46,26 @@ class StatusBar: NSView {
     private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
     private let statusBarHeight: CGFloat = 20
 
-    var leftItems = [StatusBarItem]()
-    var rightItems = [StatusBarItem]()
+    var leftItems = [StatusItem]()
+    var rightItems = [StatusItem]()
 
     override var isFlipped: Bool {
         return true;
     }
 
     func setup(_ editView: NSView) {
-
         self.translatesAutoresizingMaskIntoConstraints = false
-
         self.heightAnchor.constraint(equalToConstant: statusBarHeight).isActive = true
         self.widthAnchor.constraint(equalTo: editView.widthAnchor).isActive = true
-
         self.leadingAnchor.constraint(equalTo: editView.leadingAnchor).isActive = true
         self.trailingAnchor.constraint(equalTo: editView.trailingAnchor).isActive = true
         self.bottomAnchor.constraint(equalTo: editView.bottomAnchor).isActive = true
-
     }
 
-    func addSBItem(_ item: StatusBarItem) {
+    // Adds a status bar item. Only appends status bar items for now.
+    func addStatusItem(_ item: StatusItem) {
         item.translatesAutoresizingMaskIntoConstraints = false
         item.textColor = NSColor.black
-
         self.addSubview(item)
         item.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
 
@@ -76,16 +73,12 @@ class StatusBar: NSView {
         case .left:
             if let lastLeftItem = self.leftItems.last {
                 item.leadingAnchor.constraint(equalTo: lastLeftItem.trailingAnchor, constant: 10).isActive = true
-
-
             } else {
                 item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
             }
             leftItems.append(item)
 
         case .right:
-            item.alignment = .right
-
             if let lastRightItem = self.rightItems.last {
                 item.trailingAnchor.constraint(equalTo: lastRightItem.leadingAnchor, constant: 10).isActive = true
             } else {
@@ -95,25 +88,46 @@ class StatusBar: NSView {
         }
     }
 
-    // Update a status bar item with a new value
-    func updateSBItem(_ key: String, _ value: String) {
+    // Update a status bar item with a new value.
+    func updateStatusItem(_ key: String, _ value: String) {
         if let item = (leftItems + rightItems).first(where: { $0.key == key } )  {
             item.stringValue = value
         }
     }
 
-    // Removes status bar item with key
-    func removeSBItem(_ key: String) {
+    // Removes status bar item with a specified key.
+    func removeStatusItem(_ key: String) {
         if let item = (leftItems + rightItems).first(where: { $0.key == key } )  {
             item.removeFromSuperview()
             leftItems = leftItems.filter { $0 != item }
             rightItems = rightItems.filter { $0 != item }
         }
+
+        self.needsUpdateConstraints = true
+    }
+
+    // Update constraints of status bar items.
+    // Called when the status bar item state is modified.
+    override func updateConstraints() {
+        for item in leftItems {
+            if item == leftItems.first {
+                item.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            } else {
+                item.leadingAnchor.constraint(equalTo: leftItems[leftItems.index(of: item)! - 1].leadingAnchor).isActive = true
+            }
+        }
+        for item in rightItems {
+            if item == rightItems.first {
+                item.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+            } else {
+                item.trailingAnchor.constraint(equalTo: rightItems[rightItems.index(of: item)! + 1].trailingAnchor).isActive = true
+            }
+        }
+        super.updateConstraints()
     }
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-
         let path = NSBezierPath()
         backgroundColor.setFill()
         __NSRectFill(dirtyRect)

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -12,9 +12,9 @@ import Cocoa
 class StatusBar: NSView {
 
     private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
-    private let statusBarHeight: CGFloat = 15
+    private let statusBarHeight: CGFloat = 30
 
-    func drawStatusBar(_ gutterWidth: CGFloat, _ renderer: Renderer, _ dirtyRect: NSRect) {
-        renderer.drawSolidRect(x: GLfloat(gutterWidth), y: GLfloat(dirtyRect.height - statusBarHeight), width: GLfloat(dirtyRect.width), height: GLfloat(statusBarHeight), argb: colorToArgb(NSColor.white))
+    func drawStatusBar(_ gutterWidth: CGFloat, _ renderer: Renderer, _ dirtyRect: NSRect, _ statusBarColor: NSColor) {
+        renderer.drawSolidRect(x: GLfloat(gutterWidth), y: GLfloat(dirtyRect.height - statusBarHeight), width: GLfloat(dirtyRect.width), height: GLfloat(statusBarHeight), argb: colorToArgb(statusBarColor))
     }
 }

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -9,18 +9,44 @@
 import Foundation
 import Cocoa
 
-class StatusBar: NSView {
+enum StatusItemAlignment: String {
+    case left = "left"
+    case right = "right"
+}
 
-    enum StatusItemAlignment {
-        case left
-        case right
+class StatusBarItem: NSTextField {
+
+    var key: String = ""
+    var value: String = ""
+    var barAlignment: StatusItemAlignment
+
+    init(_ key: String, _ value: String, _ barAlignment: String) {
+        self.key = key
+        self.value = value
+        self.barAlignment = StatusItemAlignment(rawValue: barAlignment)!
+        super.init(frame: NSZeroRect)
+
+        self.isEditable = false
+        self.isSelectable = false
+        self.textColor = NSColor.labelColor
+        self.backgroundColor = NSColor.clear
+        self.lineBreakMode = .byClipping
+        self.isBezeled = false
+        self.stringValue = value
     }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class StatusBar: NSView {
 
     private let backgroundColor = NSColor(deviceWhite: 0.9, alpha: 1.0)
     private let statusBarHeight: CGFloat = 20
 
-    var leftItems = [NSTextField]()
-    var rightItems = [NSTextField]()
+    var leftItems = [StatusBarItem]()
+    var rightItems = [StatusBarItem]()
 
     override var isFlipped: Bool {
         return true;
@@ -39,14 +65,14 @@ class StatusBar: NSView {
 
     }
 
-    func addSBItem(_ item: NSTextField, alignment: StatusItemAlignment) {
+    func addSBItem(_ item: StatusBarItem) {
         item.translatesAutoresizingMaskIntoConstraints = false
         item.textColor = NSColor.black
 
         self.addSubview(item)
         item.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
 
-        switch alignment {
+        switch item.barAlignment {
         case .left:
             if let lastLeftItem = self.leftItems.last {
                 item.leadingAnchor.constraint(equalTo: lastLeftItem.trailingAnchor, constant: 10).isActive = true
@@ -69,10 +95,19 @@ class StatusBar: NSView {
         }
     }
 
-    func removeSBItem() {
-        if let item = rightItems.last {
+    // Update a status bar item with a new value
+    func updateSBItem(_ key: String, _ value: String) {
+        if let item = (leftItems + rightItems).first(where: { $0.key == key } )  {
+            item.stringValue = value
+        }
+    }
+
+    // Removes status bar item with key
+    func removeSBItem(_ key: String) {
+        if let item = (leftItems + rightItems).first(where: { $0.key == key } )  {
             item.removeFromSuperview()
-            rightItems.removeLast()
+            leftItems = leftItems.filter { $0 != item }
+            rightItems = rightItems.filter { $0 != item }
         }
     }
 


### PR DESCRIPTION
This PR adds a initial status bar implementation, which supports the addition, update and deletion of status items. 

#180 
Part of #176 
To be used with xi-editor's [#677](https://github.com/google/xi-editor/pull/677)