### PR TITLE
Fix missing param when clearing find

### DIFF
--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -158,7 +158,7 @@ extension EditViewController {
     }
 
     func clearFind() {
-        document.sendRpcAsync("find", params: ["chars": ""]) { _ in }
+        document.sendRpcAsync("find", params: ["chars": "", "case_sensitive": false]) { _ in }
     }
 
     @IBAction func performCustomFinderAction(_ sender: Any?) {


### PR DESCRIPTION
This prevents 

```
unknown json from core: ["id": 5, "error": {
    code = "-32600";
    data = "missing field `case_sensitive`";
    message = "Invalid request";
}]
```

from showing up in the logs anytime find gets dismissed.

This seems like another argument for letting core know that we've dismissed the find view? I'm not totally clear on the logic around sending this message in any case, but it isn't being handled correctly currently.