### PR TITLE
Add regex option to find context menu

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -31,7 +31,7 @@ struct LineAssoc {
 }
 
 protocol FindDelegate {
-    func find(_ term: String?, caseSensitive: Bool)
+    func find(_ term: String?, caseSensitive: Bool, regex: Bool)
     func findNext(wrapAround: Bool, allowSame: Bool)
     func findPrevious(wrapAround: Bool)
     func closeFind()

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
@@ -284,6 +284,12 @@ Gw
                             <connections>
                                 <action selector="selectWrapAroundMenuAction:" target="lKE-xV-0EG" id="B7N-nB-Wee"/>
                                 <binding destination="lKE-xV-0EG" name="value" keyPath="wrapAround" id="Pcz-D1-sYR"/>
+                            </connections>
+                        </menuItem>
+                        <menuItem title="Regex" id="rue-us-4Db">
+                            <modifierMask key="keyEquivalentModifierMask"/>
+                            <connections>
+                                <action selector="selectRegexMenuAction:" target="lKE-xV-0EG" id="6KD-C7-tlP"/>
                             </connections>
                         </menuItem>
                     </items>

--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -25,6 +25,7 @@ class FindViewController: NSViewController, NSSearchFieldDelegate {
 
     @objc var ignoreCase = true
     @objc var wrapAround = true
+    @objc var regex = false
 
     override func viewDidLoad() {
         // add recent searches menu items
@@ -67,13 +68,18 @@ class FindViewController: NSViewController, NSSearchFieldDelegate {
         ignoreCase = !ignoreCase
         sender.state = ignoreCase ? NSControl.StateValue.on : NSControl.StateValue.off
 
-        findDelegate.find(searchField.stringValue, caseSensitive: !ignoreCase)
+        findDelegate.find(searchField.stringValue, caseSensitive: !ignoreCase, regex: regex)
         findDelegate.findNext(wrapAround: wrapAround, allowSame: true)
     }
     
     @IBAction func selectWrapAroundMenuAction(_ sender: NSMenuItem) {
         wrapAround = !wrapAround
         sender.state = wrapAround ? NSControl.StateValue.on : NSControl.StateValue.off
+    }
+
+    @IBAction func selectRegexMenuAction(_ sender: NSMenuItem) {
+        regex = !regex
+        sender.state = regex ? NSControl.StateValue.on : NSControl.StateValue.off
     }
 
     @IBAction func segmentControlAction(_ sender: NSSegmentedControl) {
@@ -88,7 +94,7 @@ class FindViewController: NSViewController, NSSearchFieldDelegate {
     }
 
     @IBAction func searchFieldAction(_ sender: NSSearchField) {
-        findDelegate.find(sender.stringValue, caseSensitive: !ignoreCase)
+        findDelegate.find(sender.stringValue, caseSensitive: !ignoreCase, regex: regex)
         findDelegate.findNext(wrapAround: wrapAround, allowSame: false)
     }
 
@@ -107,7 +113,8 @@ extension EditViewController {
 
             if !findViewController.searchField.stringValue.isEmpty {
                 find(findViewController.searchField.stringValue,
-                     caseSensitive: !findViewController.ignoreCase)
+                     caseSensitive: !findViewController.ignoreCase,
+                     regex: findViewController.regex)
             }
         }
         editView.window?.makeFirstResponder(findViewController.searchField)
@@ -141,9 +148,10 @@ extension EditViewController {
         ])
     }
 
-    func find(_ term: String?, caseSensitive: Bool) {
+    func find(_ term: String?, caseSensitive: Bool, regex: Bool) {
         var params: [String: Any] = [
             "case_sensitive": caseSensitive,
+            "regex": regex,
         ]
 
         if term != nil {
@@ -190,7 +198,7 @@ extension EditViewController {
 
         case .setSearchString:
             openFind()
-            self.find(nil, caseSensitive: !findViewController.ignoreCase)
+            self.find(nil, caseSensitive: !findViewController.ignoreCase, regex: findViewController.regex)
 
         case .replaceAllInSelection:
             Swift.print("replaceAllInSelection not implemented")


### PR DESCRIPTION
In support of https://github.com/google/xi-editor/pull/658. I'm not sure what the deal is with Cocoa bindings, something in here may need a second look.