### PR TITLE
Handle errors returned from request RPCs

### DIFF
--- a/XiEditor/Dispatcher.swift
+++ b/XiEditor/Dispatcher.swift
@@ -31,10 +31,10 @@ class Dispatcher {
         return coreConnection.sendRpcAsync(rpc.method, params: rpc.params) as! O
     }
 
-    func dispatchWithCallback<E: Event, O>(_ event: E, callback: @escaping (O) -> ()) {
+    func dispatchWithCallback<E: Event, O>(_ event: E, callback: @escaping (O?, RemoteError?) -> ()) {
         let rpc = event.rpcRepresentation
-        return coreConnection.sendRpcAsync(rpc.method, params: rpc.params) { (result: Any?) in
-            callback(result as! O)
+        return coreConnection.sendRpcAsync(rpc.method, params: rpc.params) { (result: Any?, error: RemoteError?) in
+            callback(result as? O, error)
         }
     }
 }
@@ -56,7 +56,7 @@ protocol Event {
 
     func dispatch(_ dispatcher: Dispatcher) -> Output
 
-    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (Output) -> ())
+    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (Output?, RemoteError?) -> ())
 }
 
 extension Event {
@@ -74,7 +74,7 @@ extension Event {
     }
 
     /// Note: the callback may be called from an arbitrary thread
-    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (Output) -> ()) {
+    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (Output?, RemoteError?) -> ()) {
         assert(dispatchMethod == .sync)
         dispatcher.dispatchWithCallback(self, callback: callback)
     }

--- a/XiEditor/Dispatcher.swift
+++ b/XiEditor/Dispatcher.swift
@@ -31,10 +31,10 @@ class Dispatcher {
         return coreConnection.sendRpcAsync(rpc.method, params: rpc.params) as! O
     }
 
-    func dispatchWithCallback<E: Event, O>(_ event: E, callback: @escaping (O?, RemoteError?) -> ()) {
+    func dispatchWithCallback<E: Event>(_ event: E, callback: @escaping (RpcResult) -> ()) {
         let rpc = event.rpcRepresentation
-        return coreConnection.sendRpcAsync(rpc.method, params: rpc.params) { (result: Any?, error: RemoteError?) in
-            callback(result as? O, error)
+        return coreConnection.sendRpcAsync(rpc.method, params: rpc.params) { result in
+            callback(result)
         }
     }
 }
@@ -47,6 +47,9 @@ enum EventDispatchMethod {
 }
 
 protocol Event {
+    //NOTE: output is now unused; this file in general should be considered deprecated.
+    // In the future we would like to move to having a 'XiCore protocol', and then implementing that
+    // via CoreConnection or equivalent.
     associatedtype Output
 
     var method: String { get }
@@ -56,7 +59,7 @@ protocol Event {
 
     func dispatch(_ dispatcher: Dispatcher) -> Output
 
-    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (Output?, RemoteError?) -> ())
+    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (RpcResult) -> ())
 }
 
 extension Event {
@@ -74,7 +77,7 @@ extension Event {
     }
 
     /// Note: the callback may be called from an arbitrary thread
-    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (Output?, RemoteError?) -> ()) {
+    func dispatchWithCallback(_ dispatcher: Dispatcher, callback: @escaping (RpcResult) -> ()) {
         assert(dispatchMethod == .sync)
         dispatcher.dispatchWithCallback(self, callback: callback)
     }

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -17,7 +17,7 @@ import Cocoa
 struct PendingNotification {
     let method: String
     let params: Any
-    let callback: ((Any?) -> ())?
+    let callback: RpcCallback?
 }
 
 class Document: NSDocument {
@@ -111,8 +111,8 @@ class Document: NSDocument {
     override func close() {
         if let identifier = self.coreViewIdentifier {
             Events.CloseView(viewIdentifier: identifier).dispatch(dispatcher!)
-            super.close()
         }
+        super.close()
     }
     
     override var isEntireFileLoaded: Bool {
@@ -133,7 +133,7 @@ class Document: NSDocument {
     
     /// Send a notification specific to the tab. If the tab name hasn't been set, then the
     /// notification is queued, and sent when the tab name arrives.
-    func sendRpcAsync(_ method: String, params: Any, callback: ((Any?) -> ())? = nil) {
+    func sendRpcAsync(_ method: String, params: Any, callback: RpcCallback? = nil) {
         Trace.shared.trace(method, .rpc, .begin)
         if let coreViewIdentifier = coreViewIdentifier {
             let inner = ["method": method, "params": params, "view_id": coreViewIdentifier] as [String : Any]


### PR DESCRIPTION
Previously we were assuming that any response to a request was a success case.
In particular, this improves handling of errors in the case that core cannot
open a particular file.

closes #188