### PR TITLE
Add support for core->client new_view RPC

### DIFF
--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -17,9 +17,11 @@ import Foundation
 /// Describes the client side of the xi protocol. For a full(er) description of
 /// the protocol, see the [xi-core documentation](https://github.com/google/xi-editor/blob/master/doc/frontend.md).
 protocol XiClient: AnyObject {
+    /// A notificaiton that the client should open a new view.
+    func newView(viewIdentifier: String, path: String?);
     /// An update to the contents of a given view. The structure of the `update`
     /// param is described in detail in the
-    // [documentation])https://github.com/google/xi-editor/blob/master/doc/update.md).
+    /// [documentation])https://github.com/google/xi-editor/blob/master/doc/update.md).
     func update(viewIdentifier: String, update: [String: AnyObject], rev: UInt64?);
 
     /// A notification that a given view should scroll, if necessary, such

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -262,6 +262,10 @@ class CoreConnection {
         let viewIdentifier = params["view_id"] as? ViewIdentifier
         
         switch method {
+        case "new_view":
+            let path = params["path"] as? String
+            self.client?.newView(viewIdentifier: viewIdentifier!, path: path)
+
         case "update":
             let update = params["update"] as! [String: AnyObject]
             self.client?.update(viewIdentifier: viewIdentifier!, update: update, rev: nil)


### PR DESCRIPTION
This lets us initiate view opening in the core, for things like go to definition.

It feels hacky; I think it's probably time to drop NSDocument again, but that will be a solid weekend's work.