### PR TITLE
Track and manage plugin name for status items

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -310,10 +310,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
-    func addStatusItem(viewIdentifier: String, plugin: String, key: String, value: String, alignment: String) {
+    func addStatusItem(viewIdentifier: String, source: String, key: String, value: String, alignment: String) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
-            let newStatusItem = StatusItem(pluginName: plugin, key, value, alignment)
+            let newStatusItem = StatusItem(source, key, value, alignment)
             document?.editViewController?.statusBar.addStatusItem(newStatusItem)
         }
     }

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -310,10 +310,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
-    func addStatusItem(viewIdentifier: String, key: String, value: String, alignment: String) {
+    func addStatusItem(viewIdentifier: String, plugin: String, key: String, value: String, alignment: String) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
-            let newStatusItem = StatusItem(key, value, alignment)
+            let newStatusItem = StatusItem(pluginName: plugin, key, value, alignment)
             document?.editViewController?.statusBar.addStatusItem(newStatusItem)
         }
     }

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -57,7 +57,7 @@ protocol XiClient: AnyObject {
     /// A list of notifications that manages status items.
     /// Keys are unique, and alignment (left or right) cannot be
     /// changed after creating the status item.
-    func addStatusItem(viewIdentifier: String, plugin: String, key: String, value: String, alignment: String);
+    func addStatusItem(viewIdentifier: String, source: String, key: String, value: String, alignment: String);
     func updateStatusItem(viewIdentifier: String, key: String, value: String);
     func removeStatusItem(viewIdentifier: String, key: String);
 

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -57,7 +57,7 @@ protocol XiClient: AnyObject {
     /// A list of notifications that manages status items.
     /// Keys are unique, and alignment (left or right) cannot be
     /// changed after creating the status item.
-    func addStatusItem(viewIdentifier: String, key: String, value: String, alignment: String);
+    func addStatusItem(viewIdentifier: String, plugin: String, key: String, value: String, alignment: String);
     func updateStatusItem(viewIdentifier: String, key: String, value: String);
     func removeStatusItem(viewIdentifier: String, key: String);
 

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -315,10 +315,11 @@ class CoreConnection {
             client?.alert(text: message)
 
         case "add_status_item":
+            let plugin = params["plugin"] as! String
             let key = params["key"] as! String
             let value = params["value"] as! String
             let alignment = params["alignment"] as! String
-            client?.addStatusItem(viewIdentifier: viewIdentifier!, key: key, value: value, alignment: alignment)
+            client?.addStatusItem(viewIdentifier: viewIdentifier!, plugin: plugin, key: key, value: value, alignment: alignment)
 
         case "update_status_item":
             let key = params["key"] as! String

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -315,11 +315,11 @@ class CoreConnection {
             client?.alert(text: message)
 
         case "add_status_item":
-            let plugin = params["plugin"] as! String
+            let source = params["source"] as! String
             let key = params["key"] as! String
             let value = params["value"] as! String
             let alignment = params["alignment"] as! String
-            client?.addStatusItem(viewIdentifier: viewIdentifier!, plugin: plugin, key: key, value: value, alignment: alignment)
+            client?.addStatusItem(viewIdentifier: viewIdentifier!, source: source, key: key, value: value, alignment: alignment)
 
         case "update_status_item":
             let key = params["key"] as! String

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -596,7 +596,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     public func pluginStopped(_ plugin: String) {
         self.availablePlugins[plugin] = false
         let pluginStatusItems = self.statusBar.currentItems.values
-            .filter { $0.pluginName == plugin }
+            .filter { $0.source == plugin }
         pluginStatusItems.forEach { self.statusBar.removeStatusItem($0.key) }
         print("client: plugin stopped \(plugin)")
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -595,6 +595,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     
     public func pluginStopped(_ plugin: String) {
         self.availablePlugins[plugin] = false
+        let pluginStatusItems = self.statusBar.currentItems.values
+            .filter { $0.pluginName == plugin }
+        pluginStatusItems.forEach { self.statusBar.removeStatusItem($0.key) }
         print("client: plugin stopped \(plugin)")
     }
 

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -23,13 +23,15 @@ enum StatusItemAlignment: String {
 class StatusItem: NSTextField {
     let key: String
     var value: String = ""
+    let pluginName: String
     let barAlignment: StatusItemAlignment
     var barConstraints = [NSLayoutConstraint]()
 
-    init(_ key: String, _ value: String, _ barAlignment: String) {
+    init(pluginName: String, _ key: String, _ value: String, _ barAlignment: String) {
         self.key = key
         self.value = value
         self.barAlignment = StatusItemAlignment(rawValue: barAlignment)!
+        self.pluginName = pluginName
         super.init(frame: .zero)
         // Similar to what NSTextField's label convenience init creates
         self.isEditable = false

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -23,15 +23,15 @@ enum StatusItemAlignment: String {
 class StatusItem: NSTextField {
     let key: String
     var value: String = ""
-    let pluginName: String
+    let source: String
     let barAlignment: StatusItemAlignment
     var barConstraints = [NSLayoutConstraint]()
 
-    init(pluginName: String, _ key: String, _ value: String, _ barAlignment: String) {
+    init(_ source: String, _ key: String, _ value: String, _ barAlignment: String) {
         self.key = key
         self.value = value
         self.barAlignment = StatusItemAlignment(rawValue: barAlignment)!
-        self.pluginName = pluginName
+        self.source = source
         super.init(frame: .zero)
         // Similar to what NSTextField's label convenience init creates
         self.isEditable = false


### PR DESCRIPTION
Adds various methods to receive rpcs from core. PluginStopped now deletes all status items that belongs to that plugin.

companion to xi-editor's [#725](https://github.com/google/xi-editor/pull/725)