### PR TITLE
Fix bug with building xi-syntect-plugin?

### DIFF
--- a/build-rust-xcode.sh
+++ b/build-rust-xcode.sh
@@ -71,7 +71,7 @@ function build_target () {
 }
 
 build_target xi-core rust
-build_target xi-syntect-plugin rust/syntect-plugin
+build_target xi-syntect-plugin rust
 
 # move syntect plugin into plugins dir
 mkdir -p "${BUILT_PRODUCTS_DIR}/plugins/syntect/bin"


### PR DESCRIPTION
Kept getting

```
fatal error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo: can't open input file: target/x86_64-apple-darwin/release/xi-syntect-plugin (No such file or directory)
```

errors until I made this change. Not sure if anybody else ran into this, but thought I'd just submit just in case. Rust 1.27, xcode 9.4.1.