### PR TITLE
Match search panel color to theme

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -147,6 +147,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
                 window.backgroundColor = unifiedTitlebar ? color : nil
 
                 statusBar.updateStatusBarColor(newBackgroundColor: self.theme.background, newTextColor: self.theme.foreground, newUnifiedTitlebar: unifiedTitlebar)
+                findViewController.updateColor(newBackgroundColor: self.theme.background, unifiedTitlebar: unifiedTitlebar)
 
                 if color.isDark && unifiedTitlebar {
                     window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -183,7 +183,7 @@ Gw
         <scene sceneID="CRJ-r2-SVm">
             <objects>
                 <viewController storyboardIdentifier="Find View Controller" id="lKE-xV-0EG" customClass="FindViewController" customModule="XiEditor" customModuleProvider="target" sceneMemberID="viewController">
-                    <visualEffectView key="view" blendingMode="behindWindow" material="appearanceBased" state="inactive" id="NrM-ac-2ZW">
+                    <view key="view" id="NrM-ac-2ZW" wantsLayer="YES">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="56"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
@@ -347,7 +347,7 @@ Gw
                             <constraint firstAttribute="trailing" secondItem="ZGd-Q7-ois" secondAttribute="trailing" id="q13-Vo-xNG"/>
                             <constraint firstAttribute="bottom" secondItem="0fT-ae-quE" secondAttribute="bottom" id="t0p-ig-Uu0"/>
                         </constraints>
-                    </visualEffectView>
+                    </view>
                     <connections>
                         <outlet property="doneButton" destination="OLd-3g-GU4" id="inN-tK-kdf"/>
                         <outlet property="navigationButtons" destination="usm-aH-bgF" id="f6d-0g-ht5"/>

--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -75,6 +75,11 @@ class FindViewController: NSViewController, NSSearchFieldDelegate, NSControlText
         return true
     }
 
+    func updateColor(newBackgroundColor: NSColor, unifiedTitlebar: Bool) {
+        let veryLightGray = CGColor(gray: 246.0/256.0, alpha: 1.0)
+        self.view.layer?.backgroundColor = unifiedTitlebar ? newBackgroundColor.cgColor : veryLightGray
+    }
+
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
         switch commandSelector {
         case #selector(NSResponder.cancelOperation(_:)):


### PR DESCRIPTION
Here's my attempt at #194. As far as I can tell, there's no way to customize the background color of an `NSVisualEffectView`, so I changed it to a plain `NSView`. Now the search panel matches the theme's background color whenever the `unified_titlebar` preference is enabled.

Screenshots:
![findbar_solarized_light](https://user-images.githubusercontent.com/30331733/42715896-fd1fb56e-86c6-11e8-8714-af6a5d9851a9.png)
![findbar_solarized_dark](https://user-images.githubusercontent.com/30331733/42715899-ff4ee77e-86c6-11e8-8191-643a371e88bf.png)

Without `unified_titlebar`, it defaults to the standard whitish-gray color:
![findbar](https://user-images.githubusercontent.com/30331733/42715991-6acd1598-86c7-11e8-8342-612ee1d4ae6a.png)
