### PR TITLE
Added hover UI for front end

### DIFF
--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		AED22D861FE877000096E7C3 /* TextLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED22D851FE877000096E7C3 /* TextLine.swift */; };
 		AED23F181C83CBED002246CE /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED23F171C83CBEC002246CE /* EditView.swift */; };
 		E1288E8020B06E9C0068EEB9 /* StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */; };
+		E16BB89820FE42A700A0D7A1 /* HoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16BB89720FE42A600A0D7A1 /* HoverViewController.swift */; };
 		F53EA2AD1DCAA8110071ACFD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F53EA2AC1DCAA8110071ACFD /* Main.storyboard */; };
 		F53EA2AF1DCAAA170071ACFD /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */; };
 		F5BDBF371DCA9D2C0042430B /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BDBF361DCA9D2C0042430B /* Document.swift */; };
@@ -116,6 +117,7 @@
 		AED22D851FE877000096E7C3 /* TextLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLine.swift; sourceTree = "<group>"; };
 		AED23F171C83CBEC002246CE /* EditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
 		E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar.swift; sourceTree = "<group>"; };
+		E16BB89720FE42A600A0D7A1 /* HoverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoverViewController.swift; sourceTree = "<group>"; };
 		F53EA2AC1DCAA8110071ACFD /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		F5BDBF361DCA9D2C0042430B /* Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 				28F1ED491EC4C735008839BE /* Search.swift */,
 				E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */,
 				832910D820229C2D0042C32B /* Fps.swift */,
+				E16BB89720FE42A600A0D7A1 /* HoverViewController.swift */,
 				AE499DD61C82BB2B002D68AF /* Info.plist */,
 				F53EA2AC1DCAA8110071ACFD /* Main.storyboard */,
 				AE499DD11C82BB2B002D68AF /* Assets.xcassets */,
@@ -416,6 +419,7 @@
 				AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */,
 				AED22D761FE836880096E7C3 /* TextPlane.swift in Sources */,
 				AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */,
+				E16BB89820FE42A700A0D7A1 /* HoverViewController.swift in Sources */,
 				6B90DD1C1F129C1A00DF3CE2 /* PluginCommand.swift in Sources */,
 				6B53F5F21EF963EB00A4C664 /* Theme.swift in Sources */,
 				AE499DF91C82C835002D68AF /* CoreConnection.swift in Sources */,

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -332,7 +332,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
-    func showHover(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject]) {
+    func showHover(viewIdentifier: String, requestIdentifier: Int, result: String) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         if requestIdentifier == document?.editViewController?.hoverRequestID {
             DispatchQueue.main.async {

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -334,8 +334,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
 
     func showHover(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject]) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
-        DispatchQueue.main.async {
-            document?.editViewController?.showHover(withResult: result)
+        if requestIdentifier == document?.editViewController?.hoverRequestID {
+            DispatchQueue.main.async {
+                document?.editViewController?.showHover(withResult: result)
+            }
         }
     }
 

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -23,16 +23,16 @@ class BoolToControlStateValueTransformer: ValueTransformer {
     override class func transformedValueClass() -> AnyClass {
         return NSNumber.self
     }
-    
+
     override class func allowsReverseTransformation() -> Bool {
         return false
     }
-    
+
     override func transformedValue(_ value: Any?) -> Any? {
         guard let boolValue = value as? Bool else { return NSControl.StateValue.mixed }
         return boolValue ? NSControl.StateValue.on : NSControl.StateValue.off
     }
-    
+
     override func reverseTransformedValue(_ value: Any?) -> Any? {
         guard let type = value as? NSControl.StateValue else { return false }
         return type == NSControl.StateValue.on ? true : false
@@ -137,13 +137,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
             } catch let err  {
                 fatalError("Failed to create application support directory \(applicationDirectory.path). \(err)")
             }
-        } 
+        }
         return applicationDirectory
     }()
-    
+
     // The default name for XiEditor's error logs
     let defaultCoreLogName = "xi_tmp.log"
-    
+
     lazy var errorLogDirectory: URL? = {
         let logDirectory = FileManager.default.urls(
             for: .libraryDirectory,
@@ -156,8 +156,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         guard logDirectory != nil else { return nil }
         do {
             try FileManager.default.createDirectory(at: logDirectory!,
-                                                     withIntermediateDirectories: true,
-                                                     attributes: nil)
+                                                    withIntermediateDirectories: true,
+                                                    attributes: nil)
         } catch {
             // Returns nil if the log directory can't be created
             return nil
@@ -171,7 +171,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
                                                   textColor: theme.foreground)
         }
     }
-    
+
     override init() {
         ValueTransformer.setValueTransformer(
             BoolToControlStateValueTransformer(),
@@ -180,7 +180,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
 
     func applicationWillFinishLaunching(_ aNotification: Notification) {
         let collectSamplesOnBoot = true
-        
+
         self.collectTracingSamplesEnabled = collectSamplesOnBoot
         Trace.shared.trace("appWillLaunch", .main, .begin)
 
@@ -201,7 +201,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
                       "config_dir": getUserConfigDirectory()]
         dispatcher.coreConnection.sendRpcAsync("client_started",
                                                params: params)
-        
+
         // fallback values used by NSUserDefaults
         let defaultDefaults: [String: Any] = [
             USER_DEFAULTS_THEME_KEY: "InspiredGitHub",
@@ -216,7 +216,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         Trace.shared.trace("appWillLaunch", .main, .end)
         documentController = XiDocumentController()
     }
-    
+
     // Clean up temporary Xi stderr log
     func applicationWillTerminate(_ notification: Notification) {
         if let tmpErrLogFile = errorLogDirectory?.appendingPathComponent(defaultCoreLogName) {
@@ -332,6 +332,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
+    func showHover(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject]) {
+        let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
+        DispatchQueue.main.async {
+            document?.editViewController?.showHover(withResult: result)
+        }
+    }
+
     func configChanged(viewIdentifier: ViewIdentifier, changes: [String : AnyObject]) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
@@ -342,7 +349,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
     func measureWidth(args: [[String : AnyObject]]) -> [[Double]] {
         return styleMap.locked().measureWidths(args)
     }
-    
+
     func findStatus(viewIdentifier: ViewIdentifier, status: [[String : AnyObject]]) {
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
@@ -434,7 +441,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
             scrollTesters.updateValue(ScrollTester(topmostDocument), forKey: topmostDocument)
         }
     }
-    
+
     func updateRpcTracingConfig(_ enabled: Bool) {
         guard let dispatcher = self.dispatcher else { return }
         Events.TracingConfig(enabled: enabled).dispatch(dispatcher)
@@ -463,7 +470,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
             Events.SaveTrace(destination: destination, frontendSamples: Trace.shared.snapshot()).dispatch(self.dispatcher!)
         }
     }
-    
+
     @IBAction func openErrorLogFolder(_ sender: Any) {
         if let errorLogPath = errorLogDirectory?.path {
             NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: errorLogPath)

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -62,7 +62,7 @@ protocol XiClient: AnyObject {
     func removeStatusItem(viewIdentifier: String, key: String);
 
     /// A result, formatted in Markdown, that is returned from a hover request.
-    func showHover(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject])
+    func showHover(viewIdentifier: String, requestIdentifier: Int, result: String)
 
     /// A notification containing changes to the current config for the given view.
     /// - Note: The first time this message is sent, `changes` contains all defined

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -61,6 +61,9 @@ protocol XiClient: AnyObject {
     func updateStatusItem(viewIdentifier: String, key: String, value: String);
     func removeStatusItem(viewIdentifier: String, key: String);
 
+    /// A result, formatted in Markdown, that is returned from a hover request.
+    func showHover(viewIdentifier: String, requestIdentifier: Int, result: [String: AnyObject])
+
     /// A notification containing changes to the current config for the given view.
     /// - Note: The first time this message is sent, `changes` contains all defined
     // config keys and their values. Subsequent calls contain only those items which
@@ -71,7 +74,7 @@ protocol XiClient: AnyObject {
     /// where `style` is the id of the style and `strings` is an array of strings to
     /// measure. The result is an array of arrays of width measurements, in macOS "points".
     func measureWidth(args: [[String: AnyObject]]) -> [[Double]]
-    
+
     /// A notification containing the current find status.
     func findStatus(viewIdentifier: String, status: [[String: AnyObject]])
 

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -330,6 +330,10 @@ class CoreConnection {
             let key = params["key"] as! String
             client?.removeStatusItem(viewIdentifier: viewIdentifier!, key: key)
 
+        case "show_hover":
+            let requestIdentifier = params["request_id"] as! Int
+            let result = params["result"] as! [String: AnyObject]
+            client?.showHover(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
             
         case "find_status":
             let status = params["queries"] as! [[String: AnyObject]]

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -332,7 +332,7 @@ class CoreConnection {
 
         case "show_hover":
             let requestIdentifier = params["request_id"] as! Int
-            let result = params["result"] as! [String: AnyObject]
+            let result = params["result"] as! String
             client?.showHover(viewIdentifier: viewIdentifier!, requestIdentifier: requestIdentifier, result: result)
             
         case "find_status":

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -238,15 +238,6 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         self.showBlinkingCursor = self.isFrontmostView && self.isFirstResponder
     }
 
-    override func updateTrackingAreas() {
-        for area in self.trackingAreas {
-            self.removeTrackingArea(area)
-        }
-        let newTrackingArea = NSTrackingArea(rect: self.bounds, options: [.activeInActiveApp, .mouseMoved], owner: self, userInfo: nil)
-        self.addTrackingArea(newTrackingArea)
-        super.updateTrackingAreas()
-    }
-
     // MARK: - NSTextInputClient protocol
     func insertText(_ aString: Any, replacementRange: NSRange) {
         self.removeMarkedText()
@@ -259,8 +250,6 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
 
     func replacementMarkedRange(_ replacementRange: NSRange) -> NSRange {
         var markedRange = _markedRange
-
-
         if (markedRange.location == NSNotFound) {
             markedRange = _selectedRange
         }

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -238,6 +238,15 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         self.showBlinkingCursor = self.isFrontmostView && self.isFirstResponder
     }
 
+    override func updateTrackingAreas() {
+        for area in self.trackingAreas {
+            self.removeTrackingArea(area)
+        }
+        let newTrackingArea = NSTrackingArea(rect: self.bounds, options: [.activeInActiveApp, .mouseMoved], owner: self, userInfo: nil)
+        self.addTrackingArea(newTrackingArea)
+        super.updateTrackingAreas()
+    }
+
     // MARK: - NSTextInputClient protocol
     func insertText(_ aString: Any, replacementRange: NSRange) {
         self.removeMarkedText()
@@ -552,7 +561,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
         for lineIx in first..<last {
             let relLineIx = lineIx - first
             guard let line = lines[relLineIx] else {
-              continue
+                continue
             }
 
             let gutterNumber = UInt(lineIx) + 1

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -550,7 +550,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         if let event = hoverEvent {
             let hoverPosition = editView.bufferPositionFromPoint(event.locationInWindow)
             document.sendRpcAsync("request_hover", params: ["request_id": hoverRequestID, "position": ["line": hoverPosition.line, "column": hoverPosition.column]])
-            hoverRequestID += 1
         }
     }
 

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -461,6 +461,14 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     //MARK: Other system events
+    override func flagsChanged(with event: NSEvent) {
+        if event.modifierFlags.contains(.option) {
+            NSCursor.crosshair.set()
+        } else {
+            NSCursor.arrow.set()
+        }
+    }
+
     override func keyDown(with theEvent: NSEvent) {
         self.editView.inputContext?.handleEvent(theEvent);
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -554,12 +554,14 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     }
 
     @objc func sendHover() {
-        if let event = hoverEvent {
-            let hoverPosition = editView.bufferPositionFromPoint(event.locationInWindow)
-            hoverTimer?.invalidate()
-            hoverTimer = nil
-            document.sendRpcAsync("request_hover", params: ["request_id": hoverRequestID, "position": ["type": "utf8_line_char", "line": hoverPosition.line, "character": hoverPosition.column]])
-            hoverRequestID += 1
+        if !infoPopover.isShown {
+            if let event = hoverEvent {
+                let hoverPosition = editView.bufferPositionFromPoint(event.locationInWindow)
+                hoverTimer?.invalidate()
+                hoverTimer = nil
+                document.sendRpcAsync("request_hover", params: ["request_id": hoverRequestID, "position": ["type": "utf8_line_char", "line": hoverPosition.line, "character": hoverPosition.column]])
+                hoverRequestID += 1
+            }
         }
     }
 

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -162,8 +162,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     private var dragTimer: Timer?
     private var dragEvent: NSEvent?
 
-    // timers to manage hovers
-    private var hoverTimer: Timer?
     var hoverEvent: NSEvent?
 
     let statusBar = StatusBar(frame: .zero)
@@ -195,7 +193,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     override func viewDidAppear() {
         super.viewDidAppear()
         setupStatusBar()
-        editView.updateTrackingAreas()
         shadowView.setup()
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSView.frameDidChangeNotification, object: scrollView)
         // call to set initial scroll position once we know view size
@@ -236,7 +233,6 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         updateEditViewHeight()
         willScroll(to: scrollView.contentView.bounds.origin)
         updateViewportSize()
-        editView.updateTrackingAreas()
         statusBar.checkItemsFitFor(windowWidth: self.view.frame.width)
     }
 
@@ -541,23 +537,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         dragEvent = nil
     }
 
-    override func mouseMoved(with theEvent: NSEvent) {
-        if theEvent.modifierFlags.contains([.option]) {
-            if !editView.isFirstResponder {
-                editView.window?.makeFirstResponder(editView)
-            }
-            if hoverTimer == nil {
-                hoverTimer = Timer.scheduledTimer(timeInterval: TimeInterval(3), target: self, selector: #selector(sendHover), userInfo: nil, repeats: false)
-            }
-            hoverEvent = theEvent
-        }
-    }
-
     @objc func sendHover() {
         if let event = hoverEvent {
             let hoverPosition = editView.bufferPositionFromPoint(event.locationInWindow)
-            hoverTimer?.invalidate()
-            hoverTimer = nil
             document.sendRpcAsync("request_hover", params: ["request_id": hoverRequestID, "position": ["line": hoverPosition.line, "column": hoverPosition.column]])
             hoverRequestID += 1
         }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -507,6 +507,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         let gestureType = clickGestureType(event: theEvent)
 
         if gestureType == "request_hover" {
+            hoverEvent = theEvent
             sendHover()
         } else {
             document.sendRpcAsync("gesture", params: [

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -549,6 +549,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     @objc func sendHover() {
         if let event = hoverEvent {
             let hoverPosition = editView.bufferPositionFromPoint(event.locationInWindow)
+            hoverRequestID += 1
             document.sendRpcAsync("request_hover", params: ["request_id": hoverRequestID, "position": ["line": hoverPosition.line, "column": hoverPosition.column]])
         }
     }

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -172,6 +172,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         if let window = self.view.window {
             popover.appearance = window.appearance
         }
+        popover.animates = false
         popover.behavior = .transient
         return popover
     }()

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -174,7 +174,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         if let window = self.view.window {
             popover.appearance = window.appearance
         }
-        popover.behavior = .semitransient
+        popover.behavior = .transient
         return popover
     }()
 
@@ -247,6 +247,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     /// Can be called manually with the current visible origin in order to ensure the line cache
     /// is up to date.
     func willScroll(to newOrigin: NSPoint) {
+        if infoPopover.isShown {
+            infoPopover.performClose(self)
+        }
         editView.scrollOrigin = newOrigin
         shadowView.showLeftShadow = newOrigin.x > 0
         shadowView.showRightShadow = (editViewWidth.constant - (newOrigin.x + self.view.bounds.width)) > rightTextPadding

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -49,7 +49,7 @@ class HoverViewController: NSViewController {
     }()
     var resultContent: String
     var hoverView: HoverView
-    let hoverPopoverWidth: CGFloat = 500 // XCode size
+    let hoverPopoverWidth: CGFloat = 500 // XCode size for quick help popovers
 
     init(content: String) {
         self.resultContent = content
@@ -81,7 +81,7 @@ class HoverViewController: NSViewController {
     // The text container inset for top and bottom is added to the height required to
     // draw the string.
     func heightForContent() -> CGFloat {
-        // Calculates height required for a view with 500 width.
+        // Calculates height required for a text view with width = 500.
         self.hoverView.setFrameSize(NSSize(width: hoverPopoverWidth, height: 0))
 
         guard let layoutManager = self.hoverView.layoutManager else { return 0 }

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -101,12 +101,12 @@ class HoverViewController: NSViewController {
 extension EditViewController {
 
     // Puts the popover at the baseline of the chosen hover symbol.
-    func showHover(withResult result: [String: AnyObject]) {
+    func showHover(withResult result: String) {
         if infoPopover.isShown {
             infoPopover.performClose(self)
         }
 
-        let hoverContent = result["content"] as! String
+        let hoverContent = result
         let hoverViewController = HoverViewController(content: hoverContent)
         let hoverContentSize = NSSize(width: hoverViewController.hoverPopoverWidth, height: hoverViewController.heightForContent())
 

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -121,6 +121,7 @@ extension EditViewController {
             let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor
 
             infoPopover.show(relativeTo: NSRect(origin: positioningPoint, size: positioningSize), of: self.view, preferredEdge: .minY)
+            hoverRequestID += 1
             hoverEvent = nil
         }
     }

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -125,7 +125,6 @@ extension EditViewController {
             let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor
 
             infoPopover.show(relativeTo: NSRect(origin: positioningPoint, size: positioningSize), of: self.view, preferredEdge: .minY)
-            hoverRequestID += 1
             hoverEvent = nil
         }
     }

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -28,6 +28,7 @@ class HoverView: NSTextView {
         self.textContainerInset = NSSize(width: 10, height: 10)
         self.font = NSFont.systemFont(ofSize: 11)
         self.textColor = NSColor.textColor
+        self.drawsBackground = false
         self.needsLayout = true
         self.isVerticallyResizable = true
         self.alignment = .justified
@@ -46,6 +47,7 @@ class HoverViewController: NSViewController {
         scrollView.autoresizingMask = [.height]
         scrollView.contentView.wantsLayer = true
         scrollView.contentView.layer?.masksToBounds = true
+        scrollView.drawsBackground = false
         return scrollView
     }()
     var resultContent: String

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -1,0 +1,114 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Cocoa
+
+class HoverView: NSTextView {
+
+    // Lets AppKit do all the work when setting up a new text view
+    override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+        let textView = NSTextView(frame: .zero)
+        super.init(frame: frameRect, textContainer: textView.textContainer)
+    }
+
+    init(content: String) {
+        super.init(frame: .zero)
+        self.string = content
+        self.isEditable = false
+        self.textContainerInset = NSSize(width: 10, height: 10)
+        self.font = NSFont.systemFont(ofSize: 11)
+        self.textColor = NSColor.textColor
+        self.needsLayout = true
+        self.isVerticallyResizable = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class HoverViewController: NSViewController {
+
+    lazy var scrollView: NSScrollView = {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: hoverPopoverWidth, height: 0))
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.autoresizingMask = [.height]
+        return scrollView
+    }()
+    var resultContent: String
+    var hoverView: HoverView
+    let hoverPopoverWidth: CGFloat = 500 // XCode size
+
+    init(content: String) {
+        self.resultContent = content
+        self.hoverView = HoverView(content: self.resultContent)
+        super.init(nibName: nil, bundle: nil)
+        self.scrollView.documentView = hoverView
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // Required to instantiate view controller programmatically.
+    override func loadView() {
+        self.view = scrollView
+        hoverView.frame.size = scrollView.contentSize
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    func updateHoverViewColors(newBackgroundColor: NSColor, newTextColor: NSColor) {
+        self.hoverView.backgroundColor = newBackgroundColor
+        self.hoverView.textColor = newTextColor
+    }
+
+    // Returns the height required to fit the hover result.
+    // The text container inset for top and bottom is added to the height required to
+    // draw the string.
+    func heightForContent() -> CGFloat {
+        guard let layoutManager = self.hoverView.layoutManager else { return 0 }
+        guard let textContainer = self.hoverView.textContainer else { return 0 }
+
+        layoutManager.glyphRange(for: textContainer)
+        return layoutManager.usedRect(for: textContainer).height + self.hoverView.textContainerInset.height * 2
+    }
+}
+
+extension EditViewController {
+
+    // Puts the popover at the baseline of the chosen hover symbol.
+    func showHover(withResult result: [String: AnyObject]) {
+        let hoverContent = result["content"] as! String
+        let hoverViewController = HoverViewController(content: hoverContent)
+        let hoverContentSize = NSSize(width: hoverViewController.hoverPopoverWidth, height: hoverViewController.heightForContent())
+
+        hoverViewController.scrollView.documentView?.setFrameSize(hoverContentSize)
+        infoPopover.contentViewController = hoverViewController
+        infoPopover.contentSize = hoverContentSize
+
+        if let event = hoverEvent {
+            let hoverLine = editView.bufferPositionFromPoint(event.locationInWindow).line
+            let symbolBaseline = editView.lineIxToBaseline(hoverLine) * CGFloat(hoverLine)
+
+            let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height - symbolBaseline)
+            let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor
+            infoPopover.show(relativeTo: NSRect(origin: positioningPoint, size: positioningSize), of: self.view, preferredEdge: .minY)
+            hoverEvent = nil
+        }
+    }
+}

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -39,7 +39,6 @@ class HoverView: NSTextView {
 }
 
 class HoverViewController: NSViewController {
-
     lazy var scrollView: NSScrollView = {
         let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: hoverPopoverWidth, height: 0))
         scrollView.borderType = .noBorder
@@ -96,20 +95,25 @@ extension EditViewController {
 
     // Puts the popover at the baseline of the chosen hover symbol.
     func showHover(withResult result: [String: AnyObject]) {
+        if infoPopover.isShown {
+            infoPopover.performClose(self)
+        }
+
         let hoverContent = result["content"] as! String
         let hoverViewController = HoverViewController(content: hoverContent)
         let hoverContentSize = NSSize(width: hoverViewController.hoverPopoverWidth, height: hoverViewController.heightForContent())
 
+        hoverViewController.scrollView.setFrameSize(hoverContentSize)
         hoverViewController.scrollView.documentView?.setFrameSize(hoverContentSize)
-        infoPopover.contentViewController = hoverViewController
         infoPopover.contentSize = hoverContentSize
+        infoPopover.contentViewController = hoverViewController
 
         if let event = hoverEvent {
             let hoverLine = editView.bufferPositionFromPoint(event.locationInWindow).line
-            let symbolBaseline = editView.lineIxToBaseline(hoverLine) 
-
+            let symbolBaseline = editView.lineIxToBaseline(hoverLine)
             let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height - symbolBaseline)
             let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor
+
             infoPopover.show(relativeTo: NSRect(origin: positioningPoint, size: positioningSize), of: self.view, preferredEdge: .minY)
             hoverEvent = nil
         }

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -48,8 +48,11 @@ class HoverViewController: NSViewController {
         scrollView.contentView.wantsLayer = true
         scrollView.contentView.layer?.masksToBounds = true
         scrollView.drawsBackground = false
+        // At most, scroll view will be as tall as its width.
+        scrollView.heightAnchor.constraint(lessThanOrEqualToConstant: hoverPopoverWidth).isActive = true
         return scrollView
     }()
+
     var resultContent: String
     var hoverView: HoverView
     let hoverPopoverWidth: CGFloat = 500 // XCode size for quick help popovers
@@ -111,6 +114,7 @@ extension EditViewController {
 
         hoverViewController.scrollView.setFrameSize(hoverContentSize)
         hoverViewController.scrollView.documentView?.setFrameSize(hoverContentSize)
+
         infoPopover.contentSize = hoverContentSize
         infoPopover.contentViewController = hoverViewController
 

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -44,6 +44,8 @@ class HoverViewController: NSViewController {
         scrollView.borderType = .noBorder
         scrollView.hasVerticalScroller = true
         scrollView.autoresizingMask = [.height]
+        scrollView.contentView.wantsLayer = true
+        scrollView.contentView.layer?.masksToBounds = true
         return scrollView
     }()
     var resultContent: String

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -30,6 +30,7 @@ class HoverView: NSTextView {
         self.textColor = NSColor.textColor
         self.needsLayout = true
         self.isVerticallyResizable = true
+        self.alignment = .justified
     }
 
     required init?(coder: NSCoder) {
@@ -110,7 +111,7 @@ extension EditViewController {
         if let event = hoverEvent {
             let hoverLine = editView.bufferPositionFromPoint(event.locationInWindow).line
             let symbolBaseline = editView.lineIxToBaseline(hoverLine)
-            let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height - symbolBaseline)
+            let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height + editView.scrollOrigin.y - symbolBaseline)
             let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor
 
             infoPopover.show(relativeTo: NSRect(origin: positioningPoint, size: positioningSize), of: self.view, preferredEdge: .minY)

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -103,6 +103,8 @@ extension EditViewController {
         let hoverViewController = HoverViewController(content: hoverContent)
         let hoverContentSize = NSSize(width: hoverViewController.hoverPopoverWidth, height: hoverViewController.heightForContent())
 
+        guard !hoverContent.isEmpty else { return }
+
         hoverViewController.scrollView.setFrameSize(hoverContentSize)
         hoverViewController.scrollView.documentView?.setFrameSize(hoverContentSize)
         infoPopover.contentSize = hoverContentSize

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -81,6 +81,9 @@ class HoverViewController: NSViewController {
     // The text container inset for top and bottom is added to the height required to
     // draw the string.
     func heightForContent() -> CGFloat {
+        // Calculates height required for a view with 500 width.
+        self.hoverView.setFrameSize(NSSize(width: hoverPopoverWidth, height: 0))
+
         guard let layoutManager = self.hoverView.layoutManager else { return 0 }
         guard let textContainer = self.hoverView.textContainer else { return 0 }
 

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -15,7 +15,6 @@
 import Cocoa
 
 class HoverView: NSTextView {
-
     // Lets AppKit do all the work when setting up a new text view
     override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
         let textView = NSTextView(frame: .zero)

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -103,7 +103,7 @@ extension EditViewController {
 
         if let event = hoverEvent {
             let hoverLine = editView.bufferPositionFromPoint(event.locationInWindow).line
-            let symbolBaseline = editView.lineIxToBaseline(hoverLine) * CGFloat(hoverLine)
+            let symbolBaseline = editView.lineIxToBaseline(hoverLine) 
 
             let positioningPoint = NSPoint(x: event.locationInWindow.x, y: editView.frame.height - symbolBaseline)
             let positioningSize = CGSize(width: 1, height: 1) // Generic size to center popover on cursor


### PR DESCRIPTION
This is the hover part of #221. This PR adds the hover UI to Xi to work with the LSP's hover feature.

In order to use hover, **Option+Click** on the desired symbol.
This PR can be tested using [my dummy plugin](https://github.com/nangtrongvuon/xi-editor/tree/dummy-hover-plugin), or with xi-editor's [#753](https://github.com/google/xi-editor/pull/753).