### PR TITLE
[WIP] Sidebar/File Navigator

### DIFF
--- a/Sources/XiEditor/Document.swift
+++ b/Sources/XiEditor/Document.swift
@@ -60,10 +60,9 @@ class Document: NSDocument {
     override func makeWindowControllers() {
         // save this before instantiating because instantiating overwrites with the default position
         let newFrame = frameForNewWindow()
-        var windowController: NSWindowController!
         let storyboard = NSStoryboard(name: NSStoryboard.Name("Main"), bundle: nil)
-        windowController = (storyboard.instantiateController(
-            withIdentifier: NSStoryboard.SceneIdentifier("Document Window Controller")) as! NSWindowController)
+        let windowController = (storyboard.instantiateController(
+            withIdentifier: NSStoryboard.SceneIdentifier("Document Window Controller")) as! XiWindowController)
 
         if #available(OSX 10.12, *) {
             windowController.window?.tabbingIdentifier = NSWindow.TabbingIdentifier("xi-global-tab-group")
@@ -73,10 +72,16 @@ class Document: NSDocument {
             Document.tabbingMode = .automatic
         }
 
+        if sidebarItems.isEmpty {
+            windowController.hideSidebar()
+        }
+
         windowController.window?.setFrame(newFrame, display: true)
         windowController.window?.minSize = Document.minWinSize
 
-        self.editViewController = windowController.contentViewController as? EditViewController
+        guard let splitViewController = windowController.contentViewController as? NSSplitViewController else { return }
+
+        self.editViewController = splitViewController.children.last as? EditViewController
         editViewController?.document = self
         editViewController?.xiView = XiViewConnection(asyncRpc: sendRpcAsync, syncRpc: sendRpc)
         windowController.window?.delegate = editViewController

--- a/Sources/XiEditor/EditViewController.swift
+++ b/Sources/XiEditor/EditViewController.swift
@@ -227,6 +227,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     var hoverEvent: NSEvent?
 
+    private var sidebar: SidebarViewController? {
+        let splitViewController = self.parent as? NSSplitViewController
+        return splitViewController?.splitViewItems.first?.viewController as? SidebarViewController
+    }
+
     let statusBar = StatusBar(frame: .zero)
 
     // Popover that manages hover views.
@@ -254,6 +259,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         scrollView.hasHorizontalScroller = true
         scrollView.usesPredominantAxisScrolling = true
         (scrollView.contentView as? XiClipView)?.delegate = self
+        sidebar?.syncStructure()
     }
 
     override func viewDidAppear() {
@@ -903,6 +909,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
             subItem.state = NSControl.StateValue(rawValue: (subItem.title == theme) ? 1 : 0)
         }
         self.unifiedTitlebar = { self.unifiedTitlebar }()
+        sidebar?.themeChanged()
     }
     
     public func languageChanged(_ languageIdentifier: String) {

--- a/Sources/XiEditor/FileSystemItem.swift
+++ b/Sources/XiEditor/FileSystemItem.swift
@@ -1,0 +1,110 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Cocoa
+
+final class FileSystemItem {
+
+    fileprivate var relativePath: String!
+    fileprivate var parent: FileSystemItem?
+
+    public var numberOfChildren: Int {
+        return children().count
+    }
+
+    public var name: String {
+        return relativePath
+    }
+
+    static let rootFileSystemItem = URL(fileURLWithPath: "/")
+
+    var fullPath: String {
+        guard
+            let parent = self.parent,
+            let url = URL(string: parent.fullPath)?.appendingPathComponent(self.relativePath)
+        else { return self.relativePath }
+
+        return url.absoluteString
+    }
+
+    var url: URL {
+        return URL(string: self.fullPath)!
+    }
+
+    var fileURL: URL {
+        return URL(fileURLWithPath: self.fullPath)
+    }
+
+    var fileType: String {
+        return self.fileURL.pathExtension
+    }
+
+    var isDirectory: Bool {
+        var isDir: ObjCBool = false
+        FileManager.default.fileExists(atPath: self.fullPath, isDirectory: &isDir)
+        return isDir.boolValue
+    }
+
+    convenience init() {
+        self.init(path: FileSystemItem.rootFileSystemItem.path)
+    }
+
+    init(path: String, parent: FileSystemItem? = nil) {
+        self.relativePath = URL(fileURLWithPath: path).lastPathComponent
+        self.parent = parent
+    }
+
+    // MARK: - Public methods
+
+    public func child(at index: Int) -> FileSystemItem {
+        return children()[index]
+    }
+
+    // MARK: - Private methods
+
+    private func children() -> [FileSystemItem] {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        var children = [FileSystemItem]()
+
+        let valid = fileManager.fileExists(atPath: self.fullPath, isDirectory: &isDirectory)
+
+        if valid && isDirectory.boolValue {
+            if let contents = try? fileManager.contentsOfDirectory(atPath: self.fullPath) {
+                contents.forEach {
+                    // Don't add .DS_Store files. Probably should do a more rigorous
+                    // check here, and only allow certain types of files
+                    if ![".DS_Store"].contains($0) {
+                        children.append(FileSystemItem(path: $0, parent: self))
+                    }
+                }
+            }
+        }
+        return children
+    }
+
+    // MARK: - Static methods
+
+    static func createParents(url: URL) -> FileSystemItem {
+        let parentURL = url.deletingLastPathComponent()
+        let path = parentURL.absoluteString
+
+        if path == rootFileSystemItem.absoluteString {
+            return FileSystemItem()
+        }
+
+        return FileSystemItem(path: path, parent: createParents(url: parentURL))
+    }
+
+}

--- a/Sources/XiEditor/FileSystemItem.swift
+++ b/Sources/XiEditor/FileSystemItem.swift
@@ -14,13 +14,20 @@
 
 import Cocoa
 
-final class FileSystemItem {
+func == (lhs: FileSystemItem, rhs: FileSystemItem) -> Bool {
+  return lhs.fullPath == rhs.fullPath
+}
+
+final class FileSystemItem: Equatable {
 
     fileprivate var relativePath: String!
     fileprivate var parent: FileSystemItem?
+    fileprivate lazy var children: [FileSystemItem] = getChildren()
+
+    public var isExpanded: Bool = false
 
     public var numberOfChildren: Int {
-        return children().count
+        return children.count
     }
 
     public var name: String {
@@ -68,12 +75,12 @@ final class FileSystemItem {
     // MARK: - Public methods
 
     public func child(at index: Int) -> FileSystemItem {
-        return children()[index]
+        return children[index]
     }
 
     // MARK: - Private methods
 
-    private func children() -> [FileSystemItem] {
+    private func getChildren() -> [FileSystemItem] {
         let fileManager = FileManager.default
         var isDirectory: ObjCBool = false
         var children = [FileSystemItem]()

--- a/Sources/XiEditor/Main.storyboard
+++ b/Sources/XiEditor/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,12 +20,143 @@
                         </connections>
                     </window>
                     <connections>
-                        <segue destination="K7o-qN-T9e" kind="relationship" relationship="window.shadowedContentViewController" id="ilK-wy-XDq"/>
+                        <segue destination="EX6-m5-hHD" kind="relationship" relationship="window.shadowedContentViewController" id="RHE-XX-1Do"/>
                     </connections>
                 </windowController>
                 <customObject id="MN3-yk-KJt" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-269" y="-318"/>
+        </scene>
+        <!--Split View Controller-->
+        <scene sceneID="M2P-xf-6eE">
+            <objects>
+                <splitViewController id="EX6-m5-hHD" sceneMemberID="viewController">
+                    <splitViewItems>
+                        <splitViewItem canCollapse="YES" holdingPriority="260" behavior="sidebar" id="qav-1N-1nD"/>
+                        <splitViewItem id="F23-vU-Dak"/>
+                    </splitViewItems>
+                    <splitView key="splitView" dividerStyle="thin" vertical="YES" id="DXd-cC-7n2">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <connections>
+                            <outlet property="delegate" destination="EX6-m5-hHD" id="TZT-Fi-Y8A"/>
+                        </connections>
+                    </splitView>
+                    <connections>
+                        <outlet property="splitView" destination="DXd-cC-7n2" id="Gh8-al-0mI"/>
+                        <segue destination="Qb1-73-f7U" kind="relationship" relationship="splitItems" id="y7g-DR-ndf"/>
+                        <segue destination="K7o-qN-T9e" kind="relationship" relationship="splitItems" id="6FJ-q6-zPg"/>
+                    </connections>
+                </splitViewController>
+                <customObject id="3sE-PH-P3q" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="384" y="-119"/>
+        </scene>
+        <!--Sidebar View Controller-->
+        <scene sceneID="NEI-JE-2GL">
+            <objects>
+                <viewController id="Qb1-73-f7U" customClass="SidebarViewController" customModule="XiEditor" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="sPT-NP-2uF">
+                        <rect key="frame" x="0.0" y="0.0" width="238" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="33" horizontalPageScroll="10" verticalLineScroll="33" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2T-Kx-D4v">
+                                <rect key="frame" x="0.0" y="0.0" width="238" height="300"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="84F-fa-eQM">
+                                    <rect key="frame" x="0.0" y="0.0" width="238" height="300"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" multipleSelection="NO" autosaveColumns="NO" rowHeight="30" rowSizeStyle="automatic" viewBased="YES" indentationPerLevel="16" outlineTableColumn="RdH-JA-MOI" id="vMX-dv-0we">
+                                            <rect key="frame" x="0.0" y="0.0" width="238" height="300"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <size key="intercellSpacing" width="2" height="3"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn width="236" minWidth="40" maxWidth="1000" id="RdH-JA-MOI">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" id="EFd-pj-jKh">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView identifier="ItemCell" id="iFJ-1P-FQe">
+                                                            <rect key="frame" x="1" y="1" width="236" height="30"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Aly-gY-EUN">
+                                                                    <rect key="frame" x="28" y="6" width="163" height="18"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="18" id="UFv-T0-nIE"/>
+                                                                    </constraints>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Folder" drawsBackground="YES" id="Pgd-fU-Dp3">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <imageView translatesAutoresizingMaskIntoConstraints="NO" id="9g5-VW-CgT">
+                                                                    <rect key="frame" x="4" y="6" width="18" height="18"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="18" id="kel-7j-zQf"/>
+                                                                        <constraint firstAttribute="width" constant="18" id="qqv-uZ-jFc"/>
+                                                                    </constraints>
+                                                                    <imageCell key="cell" refusesFirstResponder="YES" imageScaling="proportionallyDown" image="NSFolder" id="V5q-tB-gTb"/>
+                                                                </imageView>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="9g5-VW-CgT" firstAttribute="centerY" secondItem="iFJ-1P-FQe" secondAttribute="centerY" id="769-EG-NG4"/>
+                                                                <constraint firstAttribute="trailing" secondItem="Aly-gY-EUN" secondAttribute="trailing" constant="4" id="AD4-yk-bBa"/>
+                                                                <constraint firstItem="Aly-gY-EUN" firstAttribute="centerY" secondItem="iFJ-1P-FQe" secondAttribute="centerY" id="Bh4-0j-WgM"/>
+                                                                <constraint firstItem="Aly-gY-EUN" firstAttribute="leading" secondItem="9g5-VW-CgT" secondAttribute="trailing" constant="4" id="Q8W-Li-wSC"/>
+                                                                <constraint firstItem="9g5-VW-CgT" firstAttribute="leading" secondItem="iFJ-1P-FQe" secondAttribute="leading" constant="4" id="s71-Yn-C5z"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="imageView" destination="9g5-VW-CgT" id="PAL-CT-zIL"/>
+                                                                <outlet property="textField" destination="Aly-gY-EUN" id="cwy-d8-D6R"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                            <connections>
+                                                <outlet property="dataSource" destination="Qb1-73-f7U" id="gO0-Rc-YF2"/>
+                                                <outlet property="delegate" destination="Qb1-73-f7U" id="sWh-FC-FAs"/>
+                                            </connections>
+                                        </outlineView>
+                                    </subviews>
+                                    <nil key="backgroundColor"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="aGV-3J-JI5">
+                                    <rect key="frame" x="0.0" y="284" width="179" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="MWm-AX-4qQ">
+                                    <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="S2T-Kx-D4v" firstAttribute="top" secondItem="sPT-NP-2uF" secondAttribute="top" id="AD5-52-Gx9"/>
+                            <constraint firstItem="S2T-Kx-D4v" firstAttribute="leading" secondItem="sPT-NP-2uF" secondAttribute="leading" id="KPL-QS-cuf"/>
+                            <constraint firstAttribute="trailing" secondItem="S2T-Kx-D4v" secondAttribute="trailing" id="V6l-wi-7pg"/>
+                            <constraint firstAttribute="bottom" secondItem="S2T-Kx-D4v" secondAttribute="bottom" id="jeq-vP-ApT"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="sidebar" destination="vMX-dv-0we" id="SU0-GO-9uj"/>
+                    </connections>
+                </viewController>
+                <customObject id="UtE-rk-3Rk" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1033" y="-513"/>
         </scene>
         <!--Edit View Controller-->
         <scene sceneID="LEm-46-qP4">
@@ -97,7 +228,7 @@
                 </viewController>
                 <customObject id="ySa-Ve-cwL" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="425" y="-119"/>
+            <point key="canvasLocation" x="1033" y="-119"/>
         </scene>
         <!--User Input Prompt Controller-->
         <scene sceneID="eJE-Vi-nNd">
@@ -176,7 +307,7 @@ Gw
                 </viewController>
                 <customObject id="mt0-rC-EbP" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="195" y="239.5"/>
+            <point key="canvasLocation" x="1033" y="322"/>
         </scene>
         <!--Find View Controller-->
         <scene sceneID="CRJ-r2-SVm">
@@ -267,7 +398,7 @@ Gw
                                                 <rect key="frame" x="0.0" y="74" width="404" height="22"/>
                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" state="on" borderStyle="bezel" focusRingType="none" tag="1" placeholderString="Replace" bezelStyle="round" id="PAV-4z-SXm">
                                                     <font key="font" metaFont="system"/>
-                                                    <color key="textColor" name="windowFrameTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                                 <connections>
@@ -351,7 +482,7 @@ Gw
                 <customObject id="MxZ-GG-2K0" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <userDefaultsController representsSharedInstance="YES" id="DVW-4U-qxz"/>
             </objects>
-            <point key="canvasLocation" x="1103.5" y="-171"/>
+            <point key="canvasLocation" x="1019" y="-836"/>
         </scene>
         <!--Suplementary Find View Controller-->
         <scene sceneID="U5d-nr-i4y">
@@ -475,7 +606,7 @@ Gw
                 <customObject id="TEY-bc-0Oc" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <userDefaultsController id="xgl-Q0-vom"/>
             </objects>
-            <point key="canvasLocation" x="956.5" y="167.5"/>
+            <point key="canvasLocation" x="600" y="183"/>
         </scene>
         <!--Application-->
         <scene sceneID="uLn-e8-8sb">
@@ -1058,6 +1189,11 @@ Gw
                                                 <action selector="debugSetLanguage:" target="7er-QZ-amI" id="tTz-ol-fl7"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Hide Sidebar" keyEquivalent="l" id="miX-LW-aXq">
+                                            <connections>
+                                                <action selector="toggleSidebar:" target="7er-QZ-amI" id="ZiC-3g-5LE"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Show Toolbar" keyEquivalent="t" id="DVY-H7-Ng2">
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                             <connections>
@@ -1232,6 +1368,7 @@ Gw
         </scene>
     </scenes>
     <resources>
+        <image name="NSFolder" width="32" height="32"/>
         <image name="NSLeftFacingTriangleTemplate" width="9" height="12"/>
         <image name="NSRightFacingTriangleTemplate" width="9" height="12"/>
     </resources>

--- a/Sources/XiEditor/SidebarItems.swift
+++ b/Sources/XiEditor/SidebarItems.swift
@@ -1,0 +1,53 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Singleton used across window sidebars containing an array of file system items
+/// Provides simple methods to modify the items
+/// Can listen to changes in the items by hooking into the "sidebarItemsChanged" notification
+final class SidebarItems {
+
+    static let sharedInstance = SidebarItems()
+    public var items = [FileSystemItem]()
+
+    public var isEmpty: Bool {
+        return items.isEmpty
+    }
+
+    public func addItem(_ doc: FileSystemItem) {
+        // Already exists
+        if items.firstIndex(where: { $0.fullPath == doc.fullPath }) != nil {
+            return
+        }
+
+        items.append(doc)
+        self.postItemsChangedNotification()
+    }
+
+    public func removeItem(with url: URL) {
+        if let index = items.firstIndex(where: { $0.fullPath == url.relativePath }) {
+            items.remove(at: index)
+            self.postItemsChangedNotification()
+        }
+    }
+
+    // Propagate notification for anything to listen to whenever the sidebar items are changed
+    private func postItemsChangedNotification() {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "sidebarItemsChanged"), object: nil)
+    }
+
+}
+
+let sidebarItems = SidebarItems.sharedInstance

--- a/Sources/XiEditor/SidebarItems.swift
+++ b/Sources/XiEditor/SidebarItems.swift
@@ -26,13 +26,13 @@ final class SidebarItems {
         return items.isEmpty
     }
 
-    public func addItem(_ doc: FileSystemItem) {
+    public func addItem(_ item: FileSystemItem) {
         // Already exists
-        if items.firstIndex(where: { $0.fullPath == doc.fullPath }) != nil {
+        if contains(item) {
             return
         }
 
-        items.append(doc)
+        items.append(item)
         self.postItemsChangedNotification()
     }
 
@@ -41,6 +41,10 @@ final class SidebarItems {
             items.remove(at: index)
             self.postItemsChangedNotification()
         }
+    }
+
+    private func contains(_ item: FileSystemItem) -> Bool {
+        return items.contains(item)
     }
 
     // Propagate notification for anything to listen to whenever the sidebar items are changed

--- a/Sources/XiEditor/SidebarViewController.swift
+++ b/Sources/XiEditor/SidebarViewController.swift
@@ -1,0 +1,170 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Cocoa
+
+class SidebarViewController: NSViewController {
+
+    @IBOutlet weak var sidebar: NSOutlineView!
+
+    private var styling: AppStyling {
+        return (NSApplication.shared.delegate as! AppDelegate).xiClient
+    }
+
+    var theme: Theme {
+        return styling.theme
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Setup notification observer for when the sidebar items change
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.updateItems),
+            name: NSNotification.Name(rawValue: "sidebarItemsChanged"),
+            object: nil
+        )
+
+        sidebar.doubleAction = #selector(self.doubleClicked)
+
+        self.updateItems()
+    }
+
+    override func viewWillAppear() {
+        themeChanged()
+    }
+
+    /// On theme change, set the sidebar apeparance and background color
+    public func themeChanged() {
+        if (self.theme.background.isDark) {
+            if #available(OSX 10.14, *) {
+                sidebar.appearance = NSAppearance(named: .darkAqua)
+            } else {
+                sidebar.appearance = NSAppearance(named: .vibrantDark)
+            }
+        } else {
+            sidebar.appearance = NSAppearance(named: .aqua)
+        }
+
+        sidebar.backgroundColor = self.theme.background
+    }
+
+    /// TODO: Sync the structure (expanded/collapsed/selected) of each windows sidebar
+    public func syncStructure() {
+
+    }
+
+    /// Called when the a row in the sidebar is double clicked
+    @objc private func doubleClicked(_ sender: Any?) {
+        let clickedRow = sidebar.item(atRow: sidebar.clickedRow)
+
+        if sidebar.isItemExpanded(clickedRow) {
+            sidebar.collapseItem(clickedRow)
+        } else {
+            sidebar.expandItem(clickedRow)
+        }
+    }
+
+    @objc private func updateItems() {
+        self.sidebar.reloadData()
+    }
+
+}
+
+// MARK: - Sidebar NSOutlineViewDataSource
+
+extension SidebarViewController: NSOutlineViewDataSource {
+
+    // Number of items in the sidebar
+    func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+        guard let item = item as? FileSystemItem else { return sidebarItems.items.count }
+        return item.numberOfChildren
+    }
+
+    // Items to be added to sidebar
+    func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+        guard let item = item as? FileSystemItem else { return sidebarItems.items[index] }
+        return item.child(at: index)
+    }
+
+    // Whether rows are expandable by an arrow
+    func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
+        guard let item = item as? FileSystemItem else { return false }
+        return item.numberOfChildren != 0
+    }
+
+    // Height of each row
+    func outlineView(_ outlineView: NSOutlineView, heightOfRowByItem item: Any) -> CGFloat {
+        return 20.0
+    }
+
+    // When a row is clicked on should it be selected
+    func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
+        return true
+    }
+
+    // When a row is selected
+    func outlineViewSelectionDidChange(_ notification: Notification) {
+        guard
+            let outlineView = notification.object as? NSOutlineView,
+            let doc = outlineView.item(atRow: outlineView.selectedRow) as? FileSystemItem
+            else { return }
+
+        let rows = IndexSet(integersIn: 0..<outlineView.numberOfRows)
+
+        rows.compactMap { outlineView.rowView(atRow: $0, makeIfNecessary: false) }
+            .forEach { $0.backgroundColor = $0.isSelected ? .selectedControlColor : .clear }
+
+        if doc.isDirectory { return }
+
+        // Get the document controller and open the selected document into a new tab
+        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            appDelegate.documentController.openDocumentIntoNewTab(
+                withContentsOf: doc.fileURL,
+                display: true,
+                completionHandler: { (document, alreadyOpen, error) in
+                    if let error = error {
+                        print("error opening file \(error)")
+                    }
+            });
+        }
+    }
+
+}
+
+// MARK: - Sidebar NSOutlineViewDelegate
+
+extension SidebarViewController: NSOutlineViewDelegate {
+
+    // Create a cell given an item and set its properties
+    func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
+        guard let item = item as? FileSystemItem else { return nil }
+
+        let view = outlineView.makeView(
+            withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "ItemCell"),
+            owner: self
+        ) as? NSTableCellView
+        view?.textField?.stringValue = item.name
+
+        if item.isDirectory {
+            view?.imageView?.image = NSImage(named: NSImage.folderName)
+        } else {
+            view?.imageView?.image = NSWorkspace.shared.icon(forFileType: item.fileType)
+        }
+
+        return view
+    }
+
+}

--- a/Sources/XiEditor/XiDocumentController.swift
+++ b/Sources/XiEditor/XiDocumentController.swift
@@ -110,6 +110,16 @@ class XiDocumentController: NSDocumentController, AlertPresenting {
         openPanel.showsHiddenFiles = true
         return super.runModalOpenPanel(openPanel, forTypes: types)
     }
+
+    public func openDocumentIntoNewTab(withContentsOf url: URL,
+                                       display displayDocument: Bool,
+                                       completionHandler: @escaping (NSDocument?, Bool, Error?) -> Void) {
+        if #available(OSX 10.12, *) {
+            Document.tabbingMode = .preferred
+        }
+
+        self.openDocument(withContentsOf: url, display: displayDocument, completionHandler: completionHandler)
+    }
     
     override func openDocument(withContentsOf url: URL,
                                display displayDocument: Bool,

--- a/Sources/XiEditor/XiWindowController.swift
+++ b/Sources/XiEditor/XiWindowController.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Cocoa
 import AppKit.NSWindowController
 
 final class XiWindowController: NSWindowController {
@@ -36,5 +37,21 @@ final class XiWindowController: NSWindowController {
         windowTitle += displayName
         
         return windowTitle
+    }
+
+    private var sidebarSplitItem: NSSplitViewItem? {
+        return (contentViewController as? NSSplitViewController)?.splitViewItems.first
+    }
+
+    override var acceptsFirstResponder: Bool {
+        return true
+    }
+
+    public func hideSidebar() {
+        sidebarSplitItem?.isCollapsed = true
+    }
+
+    public func showSidebar() {
+        sidebarSplitItem?.isCollapsed = false
     }
 }

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -174,9 +174,9 @@
 		832910D820229C2D0042C32B /* Fps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fps.swift; sourceTree = "<group>"; };
 		95368BAA21D0B466000FAC40 /* Annotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Annotation.swift; sourceTree = "<group>"; };
 		95FD9934218689A500C32AF1 /* MarkerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerBar.swift; sourceTree = "<group>"; };
-		A1F91B3522A1F34600E1AC6C /* SidebarItems.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarItems.swift; sourceTree = "<group>"; };
+		A1F91B3522A1F34600E1AC6C /* SidebarItems.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SidebarItems.swift; sourceTree = "<group>"; };
 		A1F91B3622A1F34700E1AC6C /* FileSystemItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileSystemItem.swift; sourceTree = "<group>"; };
-		A1F91B3722A1F34700E1AC6C /* SidebarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarViewController.swift; sourceTree = "<group>"; };
+		A1F91B3722A1F34700E1AC6C /* SidebarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SidebarViewController.swift; sourceTree = "<group>"; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* plugins */ = {isa = PBXFileReference; lastKnownFileType = text; path = plugins; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/XiEditor.xcodeproj/project.pbxproj
+++ b/XiEditor.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		832910D920229C2D0042C32B /* Fps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832910D820229C2D0042C32B /* Fps.swift */; };
 		95368BAB21D0B466000FAC40 /* Annotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368BAA21D0B466000FAC40 /* Annotation.swift */; };
 		95FD9935218689A500C32AF1 /* MarkerBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95FD9934218689A500C32AF1 /* MarkerBar.swift */; };
+		A1F91B3822A1F34700E1AC6C /* SidebarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F91B3522A1F34600E1AC6C /* SidebarItems.swift */; };
+		A1F91B3922A1F34700E1AC6C /* FileSystemItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F91B3622A1F34700E1AC6C /* FileSystemItem.swift */; };
+		A1F91B3A22A1F34700E1AC6C /* SidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F91B3722A1F34700E1AC6C /* SidebarViewController.swift */; };
 		AE0243F61E4BDF8A00641BDA /* StyleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0243F51E4BDF8A00641BDA /* StyleMap.swift */; };
 		AE041BA61D4327EB0069AB8B /* plugins in Resources */ = {isa = PBXBuildFile; fileRef = AE041BA51D4327EB0069AB8B /* plugins */; };
 		AE168C5C1E4AD87B008249AE /* LineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE168C5B1E4AD87B008249AE /* LineCache.swift */; };
@@ -155,9 +158,9 @@
 		3FC496EE22448332003D1533 /* MeasureWidth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureWidth.swift; sourceTree = "<group>"; };
 		3FD5240F2268C5B100843657 /* CoreRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRequest.swift; sourceTree = "<group>"; };
 		3FE905F7225F13BD008F0CAF /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
-		4DC153D22165202B000EB215 /* XiWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiWindowController.swift; sourceTree = "<group>"; };
+		4DC153D22165202B000EB215 /* XiWindowController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = XiWindowController.swift; sourceTree = "<group>"; };
 		4DCB4AEF20576A6E00476F75 /* fonts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fonts; sourceTree = "<group>"; };
-		6038770620057B4500AABF17 /* XiDocumentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiDocumentController.swift; sourceTree = "<group>"; };
+		6038770620057B4500AABF17 /* XiDocumentController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = XiDocumentController.swift; sourceTree = "<group>"; };
 		6057C52421A07F1900F6BD47 /* LoggingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingUtilities.swift; sourceTree = "<group>"; };
 		6083722E2058597B00E9CF5D /* ShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowView.swift; sourceTree = "<group>"; };
 		6B0C298A2033C39500EA07AF /* XiWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XiWindow.swift; sourceTree = "<group>"; };
@@ -171,13 +174,16 @@
 		832910D820229C2D0042C32B /* Fps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fps.swift; sourceTree = "<group>"; };
 		95368BAA21D0B466000FAC40 /* Annotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Annotation.swift; sourceTree = "<group>"; };
 		95FD9934218689A500C32AF1 /* MarkerBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerBar.swift; sourceTree = "<group>"; };
+		A1F91B3522A1F34600E1AC6C /* SidebarItems.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarItems.swift; sourceTree = "<group>"; };
+		A1F91B3622A1F34700E1AC6C /* FileSystemItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileSystemItem.swift; sourceTree = "<group>"; };
+		A1F91B3722A1F34700E1AC6C /* SidebarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarViewController.swift; sourceTree = "<group>"; };
 		AE0243F51E4BDF8A00641BDA /* StyleMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleMap.swift; sourceTree = "<group>"; };
 		AE041B971D4323460069AB8B /* build-rust-xcode.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-rust-xcode.sh"; sourceTree = "<group>"; };
 		AE041BA51D4327EB0069AB8B /* plugins */ = {isa = PBXFileReference; lastKnownFileType = text; path = plugins; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE168C5B1E4AD87B008249AE /* LineCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineCache.swift; sourceTree = "<group>"; };
 		AE228F5C1C897CE7000E9B0F /* xi-core */ = {isa = PBXFileReference; lastKnownFileType = text; path = "xi-core"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE499DCC1C82BB2B002D68AF /* XiEditor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XiEditor.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		AE499DCF1C82BB2B002D68AF /* AppDelegate.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AE499DD11C82BB2B002D68AF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AE499DD61C82BB2B002D68AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AE499DDB1C82BB2B002D68AF /* XiEditorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XiEditorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -213,7 +219,7 @@
 		E1288E7F20B06E9C0068EEB9 /* StatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar.swift; sourceTree = "<group>"; };
 		E16BB89720FE42A600A0D7A1 /* HoverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HoverViewController.swift; sourceTree = "<group>"; };
 		F53EA2AC1DCAA8110071ACFD /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		F53EA2AE1DCAAA170071ACFD /* EditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EditViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		F5BDBF361DCA9D2C0042430B /* Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -366,6 +372,9 @@
 		AE499DCE1C82BB2B002D68AF /* XiEditor */ = {
 			isa = PBXGroup;
 			children = (
+				A1F91B3622A1F34700E1AC6C /* FileSystemItem.swift */,
+				A1F91B3522A1F34600E1AC6C /* SidebarItems.swift */,
+				A1F91B3722A1F34700E1AC6C /* SidebarViewController.swift */,
 				3F9C4E7B223D7E1F00669C75 /* Core */,
 				AED22D741FE8366D0096E7C3 /* XiTextPlane */,
 				6BA1873A1FDDD7B6008220DA /* XiClipView.swift */,
@@ -745,13 +754,16 @@
 				6B53F5F21EF963EB00A4C664 /* Theme.swift in Sources */,
 				AE499DF91C82C835002D68AF /* RPCSending.swift in Sources */,
 				6083722F2058597B00E9CF5D /* ShadowView.swift in Sources */,
+				A1F91B3822A1F34700E1AC6C /* SidebarItems.swift in Sources */,
 				3FC496EF22448332003D1533 /* MeasureWidth.swift in Sources */,
 				E1288E8020B06E9C0068EEB9 /* StatusBar.swift in Sources */,
+				A1F91B3922A1F34700E1AC6C /* FileSystemItem.swift in Sources */,
 				AEC4F6CA1FFB02F10060E10E /* Trace.swift in Sources */,
 				3F9C4E7D223D7E3200669C75 /* Types.swift in Sources */,
 				6BF9575B1FD70C420010BAE6 /* Client.swift in Sources */,
 				AED23F181C83CBED002246CE /* EditView.swift in Sources */,
 				D8D319F0218CB39A00D108D4 /* XiCore.swift in Sources */,
+				A1F91B3A22A1F34700E1AC6C /* SidebarViewController.swift in Sources */,
 				95368BAB21D0B466000FAC40 /* Annotation.swift in Sources */,
 				AE499DD01C82BB2B002D68AF /* AppDelegate.swift in Sources */,
 				3FC496ED22447E37003D1533 /* ReplaceStatus.swift in Sources */,


### PR DESCRIPTION
Currently a work in progress with a few things to get ironed out. I thought I'd open this PR just to get some initial feedback and/or suggestions regarding the UI, UX and the overall implementation.

Right now i'm just letting the user choose either a folder or file. If they choose a file, just open it as per usual, if they choose a folder then we render the contents of that folder into the sidebar.

The default system folder icon is being used, and the file icons are the specific icons for that file type using the `NSWorkspace.shared.icon(forFileType: item.fileType)` method. These can be changed to custom icons, along with the disclosure arrows next to the icons.

### Still Todo
- [ ] Sync the structure (expanded/collapsed/selected) of each windows sidebar. Currently when a file is opened in a new tab, the root folder is collapsed
- [ ] Possibly restore sidebar folders when the app it quit and relaunched

### Thoughts on behaviour

Currently when a file is clicked on it opens into a new tab (unless it is already open in the current tab). This mimics apps like Sublime Text and VS Code, although more native apps like Xcode (when tabs are open) open the selected file into the current tab. I'm not sure what a better user experience is, but since files aren't autosaved, opening a file into the current tab may not work the best.

Also, each window/tab has its own instance of the sidebar. This is a side effect of creating a new window per document and not much can be done at the moment about this. As a result, memory usage is increased for each new tab. Although, a singleton is used for the actual sidebar data so the complexity there is reduced slightly.

As discussed in #142 this is just a basic implementation to get a file tree rendering in a sidebar. Changes will probably have to be made later for when/if core gets support for workspaces.

### Screenshot of current UI

![screenshot](https://i.imgur.com/oKNDBCy.png)

Closes #142 
Closes #156 