### PR TITLE
Fix memory leak when closing windows

### DIFF
--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -60,7 +60,7 @@ class Document: NSDocument {
     var tabbingIdentifier: String
     
 	var pendingNotifications: [PendingNotification] = [];
-    var editViewController: EditViewController?
+    weak var editViewController: EditViewController?
 
     /// Returns `true` if this document contains no data.
     var isEmpty: Bool {

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -134,7 +134,7 @@ class EditView: NSView, NSTextInputClient, TextPlaneDelegate {
     var gutterXPad: CGFloat = 8
     var gutterCache: GutterCache?
 
-    var dataSource: EditViewDataSource!
+    weak var dataSource: EditViewDataSource!
 
     var lastDragLineCol: (Int, Int)?
     var timer: Timer?

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -15,7 +15,7 @@
 import Cocoa
 
 /// The EditViewDataSource protocol describes the properties that an editView uses to determine how to render its contents.
-protocol EditViewDataSource {
+protocol EditViewDataSource: class {
     var lines: LineCache<LineAssoc> { get }
     var styleMap: StyleMap { get }
     var theme: Theme { get }
@@ -147,7 +147,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
                 window.backgroundColor = unifiedTitlebar ? color : nil
 
                 statusBar.updateStatusBarColor(newBackgroundColor: self.theme.background, newTextColor: self.theme.foreground, newUnifiedTitlebar: unifiedTitlebar)
-                findViewController.updateColor(newBackgroundColor: self.theme.background, unifiedTitlebar: unifiedTitlebar)
+//                findViewController.updateColor(newBackgroundColor: self.theme.background, unifiedTitlebar: unifiedTitlebar)
 
                 if color.isDark && unifiedTitlebar {
                     window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -30,7 +30,7 @@ struct LineAssoc {
     var textLine: TextLine
 }
 
-protocol FindDelegate {
+protocol FindDelegate: class {
     func find(_ term: String?, caseSensitive: Bool, regex: Bool, wholeWords: Bool)
     func findNext(wrapAround: Bool, allowSame: Bool)
     func findPrevious(wrapAround: Bool)
@@ -147,7 +147,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
                 window.backgroundColor = unifiedTitlebar ? color : nil
 
                 statusBar.updateStatusBarColor(newBackgroundColor: self.theme.background, newTextColor: self.theme.foreground, newUnifiedTitlebar: unifiedTitlebar)
-//                findViewController.updateColor(newBackgroundColor: self.theme.background, unifiedTitlebar: unifiedTitlebar)
+                findViewController.updateColor(newBackgroundColor: self.theme.background, unifiedTitlebar: unifiedTitlebar)
 
                 if color.isDark && unifiedTitlebar {
                     window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)

--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -16,7 +16,7 @@ import Cocoa
 import Swift
 
 class FindViewController: NSViewController, NSSearchFieldDelegate, NSControlTextEditingDelegate {
-    var findDelegate: FindDelegate!
+    weak var findDelegate: FindDelegate!
 
     @IBOutlet weak var searchField: NSSearchField!
     @IBOutlet weak var navigationButtons: NSSegmentedControl!

--- a/XiEditor/XiClipView.swift
+++ b/XiEditor/XiClipView.swift
@@ -14,12 +14,12 @@
 
 import Cocoa
 
-protocol ScrollInterested {
+protocol ScrollInterested: class {
     func willScroll(to newOrigin: NSPoint);
 }
 
 class XiClipView: NSClipView {
-    var delegate: ScrollInterested?
+    weak var delegate: ScrollInterested?
 
     override func scroll(to newOrigin: NSPoint) {
         delegate?.willScroll(to: newOrigin)

--- a/XiEditor/XiTextPlane/TextPlane.swift
+++ b/XiEditor/XiTextPlane/TextPlane.swift
@@ -154,5 +154,8 @@ class TextPlaneLayer : NSOpenGLLayer, FpsObserver {
         renderer.endDraw()
     }
 
+    override func releaseCGLPixelFormat(_ pf: CGLPixelFormatObj) {
+        // CGLPixelFormats already seem to be released; leaving the default implementation causes a crash.
+    }
 }
 


### PR DESCRIPTION
This is a potential solution to #231. It fixes the `EditViewController` memory leak, and also the crash that surfaced when trying to fix the leak.

## Memory leak
Solving the memory leak only required weakening a few references to `EditViewController`. I still don't understand why commenting out `findViewController.updateColor(...)` helped, but that turns out not to be necessary if `FindViewController.findDelegate` is weak.

## Crash
What appears to have happened is that `CGLPixelFormat` objects were getting released one time too many, which caused a problem as soon as their memory was reallocated for something else. (The extra release didn't happen when all the ViewControllers were kept in memory.) The best fix I could find was to override `TextPlaneLayer.releaseCGLPixelFormat(...)` with an empty implementation, which prevents one of the releases. I'm not quite sure if that's an appropriate solution or a hacky workaround, but it seems to work pretty well. 😄