### PR TITLE
Fix find view background not applying

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -147,6 +147,7 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
                 window.backgroundColor = unifiedTitlebar ? color : nil
 
                 statusBar.updateStatusBarColor(newBackgroundColor: self.theme.background, newTextColor: self.theme.foreground, newUnifiedTitlebar: unifiedTitlebar)
+                findViewController.updateColor(newBackgroundColor: self.theme.background, unifiedTitlebar: unifiedTitlebar)
 
                 if color.isDark && unifiedTitlebar {
                     window.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)


### PR DESCRIPTION
The call to set/update the find view background by @ryanbloom in c983d98 seems to have been removed. This PR just adds it back in, as currently the find view's backing layer doesn't get set:

<img width="1107" alt="screen shot 2018-07-27 at 8 44 17 pm" src="https://user-images.githubusercontent.com/20056300/43316926-4aed217e-91de-11e8-8a3b-ac04051b42c0.png">
