### PR TITLE
Fix xi-editor GPU switching

### DIFF
--- a/XiEditor/Info.plist
+++ b/XiEditor/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDocumentTypes</key>

--- a/XiEditor/XiTextPlane/TextPlane.swift
+++ b/XiEditor/XiTextPlane/TextPlane.swift
@@ -111,6 +111,7 @@ class TextPlaneLayer : NSOpenGLLayer, FpsObserver {
 
     override func copyCGLPixelFormat(forDisplayMask mask: UInt32) -> CGLPixelFormatObj {
         let attr = [
+            NSOpenGLPixelFormatAttribute(NSOpenGLPFAAllowOfflineRenderers),
             NSOpenGLPixelFormatAttribute(NSOpenGLPFAOpenGLProfile),
             NSOpenGLPixelFormatAttribute(NSOpenGLProfileVersion3_2Core),
             NSOpenGLPixelFormatAttribute(NSOpenGLPFAColorSize), 24,


### PR DESCRIPTION
This fixes #238 and #189 by adding attribute to not switch to dedicated GPU for macs that have an integrated GPU