### PR TITLE
Give all windows the same tabbing identifier

### DIFF
--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -22,18 +22,8 @@ struct PendingNotification {
 
 class Document: NSDocument {
 
-    /// used internally to keep track of groups of tabs
-    static fileprivate var _nextTabbingIdentifier = 0
-
-    /// returns the next available tab group identifer. When we create a new window,
-    /// if it is not part of an existing tab group it is assigned a new one.
-    static private func nextTabbingIdentifier() -> String {
-        _nextTabbingIdentifier += 1
-        return "tab-group-\(_nextTabbingIdentifier)"
-    }
-
-    /// if set, should be used as the tabbingIdentifier of new documents' windows.
-    static var preferredTabbingIdentifier: String?
+    @available(OSX 10.12, *)
+    static var tabbingMode = NSWindow.TabbingMode.automatic
 
     // minimum size for a new or resized window
     static var minWinSize = NSSize(width: 240, height: 160)
@@ -51,15 +41,8 @@ class Document: NSDocument {
             self.pendingNotifications.removeAll()
         }
     }
-    
-    /// Identifier used to group windows together into tabs.
-    /// - Todo: I suspect there is some potential confusion here around dragging tabs into and out of windows? 
-    /// I.e I'm not sure if the system ever modifies the tabbingIdentifier on our windows,
-    /// which means these could get out of sync. But: nothing obviously bad happens when I test it.
-    /// If this is problem we could use KVO to keep these in sync.
-    var tabbingIdentifier: String
-    
-	var pendingNotifications: [PendingNotification] = [];
+
+    var pendingNotifications: [PendingNotification] = [];
     weak var editViewController: EditViewController?
 
     /// Returns `true` if this document contains no data.
@@ -69,7 +52,6 @@ class Document: NSDocument {
     
     override init() {
         dispatcher = (NSApplication.shared.delegate as? AppDelegate)?.dispatcher
-        tabbingIdentifier = Document.preferredTabbingIdentifier ?? Document.nextTabbingIdentifier()
         super.init()
         // I'm not 100% sure this is necessary but it can't _hurt_
         self.hasUndoManager = false
@@ -84,11 +66,11 @@ class Document: NSDocument {
             withIdentifier: NSStoryboard.SceneIdentifier(rawValue: "Document Window Controller")) as! NSWindowController
         
         if #available(OSX 10.12, *) {
-            windowController.window?.tabbingIdentifier = NSWindow.TabbingIdentifier(rawValue: tabbingIdentifier)
-            // preferredTabbingIdentifier is set when a new document is created with cmd-T. When this is the case, set the window's tabbingMode.
-            if Document.preferredTabbingIdentifier != nil {
-                windowController.window?.tabbingMode = .preferred
-            }
+            windowController.window?.tabbingIdentifier = NSWindow.TabbingIdentifier(rawValue: "xi-global-tab-group")
+            // Temporarily override the user's preference based on which menu item was selected
+            windowController.window?.tabbingMode = Document.tabbingMode
+            // Reset for next time
+            Document.tabbingMode = .automatic
         }
         
         windowController.window?.setFrame(newFrame, display: true)

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -199,6 +199,11 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
         NotificationCenter.default.addObserver(self, selector: #selector(EditViewController.frameDidChangeNotification(_:)), name: NSView.frameDidChangeNotification, object: scrollView)
         // call to set initial scroll position once we know view size
         redrawEverything()
+
+        if #available(OSX 10.12, *) {
+            // tabbingMode may have been overridden previously
+            self.view.window?.tabbingMode = .automatic
+        }
     }
 
     func setupStatusBar() {
@@ -578,11 +583,16 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
 
     // we intercept this method to check if we should open a new tab
     @objc func newDocument(_ sender: NSMenuItem?) {
-        // this tag is a property of the New Tab menu item, set in interface builder
-        if sender?.tag == 10 {
-            Document.preferredTabbingIdentifier = document.tabbingIdentifier
-        } else {
-            Document.preferredTabbingIdentifier = nil
+        if #available(OSX 10.12, *) {
+            if sender?.tag == 10 {
+                // Tag 10 is the New Tab menu item
+                Document.tabbingMode = .preferred
+            } else if sender?.tag == 11 {
+                // Tag 11 is the New Window menu item
+                Document.tabbingMode = .disallowed
+            } else {
+                Document.tabbingMode = .automatic
+            }
         }
         // pass the message to the intended recipient
         NSDocumentController.shared.newDocument(sender)

--- a/XiEditor/Main.storyboard
+++ b/XiEditor/Main.storyboard
@@ -447,7 +447,7 @@ Gw
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="File" id="zqD-KZ-Zvt">
                                     <items>
-                                        <menuItem title="New" keyEquivalent="n" id="vc6-rD-brY">
+                                        <menuItem title="New Window" tag="11" keyEquivalent="n" id="vc6-rD-brY">
                                             <connections>
                                                 <action selector="newDocument:" target="7er-QZ-amI" id="RMh-4o-lEC"/>
                                             </connections>


### PR DESCRIPTION
This fixes a minor bug I found with tabbing behavior: if you create two separate windows (⌘N ⌘N), Xi won't let you drag tabs between them. Apparently this is because the windows are given different tabbing identifiers—if I remove that code, the problem goes away. As far as I can tell, the new tab and new window behavior remains exactly the same.