### PR TITLE
Update copyright messages to xi-editor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,10 @@
+# This is the list of xi-editor authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Google LLC
+Colin Rofls
+Lê Viết Hoàng Dũng
+Anna Scholtz
+Markus Ast

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,17 @@ frustration later on.
 All submissions, including submissions by project members, require review. We
 use Github pull requests for this purpose.
 
+Please see [the xi-editor contribution guidelines](https://github.com/google/xi-editor/blob/master/CONTRIBUTING.md) about guidelines for contributors with write access.
+
+If your name does not already appear in the [AUTHORS] file, please feel free to
+add it as part of your patch.
+
+### Code of conduct
+
+We are committed to preserving and fostering a diverse, welcoming community. This
+project follows the
+[Fuchsia Code of Conduct](https://fuchsia.googlesource.com/docs/+/master/CODE_OF_CONDUCT.md).
+
 ### The small print
 Contributions made by corporations are covered by a different agreement than
 the one above, the Software Grant and Corporate Contributor License Agreement.

--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Client.swift
+++ b/XiEditor/Client.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/CoreConnection.swift
+++ b/XiEditor/CoreConnection.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Dispatcher.swift
+++ b/XiEditor/Dispatcher.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/EditContainerView.swift
+++ b/XiEditor/EditContainerView.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/EditView.swift
+++ b/XiEditor/EditView.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Fps.swift
+++ b/XiEditor/Fps.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/HoverViewController.swift
+++ b/XiEditor/HoverViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc. All rights reserved.
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Info.plist
+++ b/XiEditor/Info.plist
@@ -42,7 +42,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2016 Google Inc. All rights reserved.</string>
+	<string>Copyright 2016 The xi-editor Authors.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/XiEditor/LineCache.swift
+++ b/XiEditor/LineCache.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/PluginCommand.swift
+++ b/XiEditor/PluginCommand.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/ShadowView.swift
+++ b/XiEditor/ShadowView.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/StatusBar.swift
+++ b/XiEditor/StatusBar.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/StyleMap.swift
+++ b/XiEditor/StyleMap.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Theme.swift
+++ b/XiEditor/Theme.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/Trace.swift
+++ b/XiEditor/Trace.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/UnfairLock.swift
+++ b/XiEditor/UnfairLock.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/UserInputPromptController.swift
+++ b/XiEditor/UserInputPromptController.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiClipView.swift
+++ b/XiEditor/XiClipView.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiDocumentController.swift
+++ b/XiEditor/XiDocumentController.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/Atlas.swift
+++ b/XiEditor/XiTextPlane/Atlas.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/Renderer.swift
+++ b/XiEditor/XiTextPlane/Renderer.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/ShaderProgram.swift
+++ b/XiEditor/XiTextPlane/ShaderProgram.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/TextLine.swift
+++ b/XiEditor/XiTextPlane/TextLine.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/TextPlane.swift
+++ b/XiEditor/XiTextPlane/TextPlane.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/solid.f.glsl
+++ b/XiEditor/XiTextPlane/solid.f.glsl
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/solid.v.glsl
+++ b/XiEditor/XiTextPlane/solid.v.glsl
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/text.f.glsl
+++ b/XiEditor/XiTextPlane/text.f.glsl
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiTextPlane/text.v.glsl
+++ b/XiEditor/XiTextPlane/text.v.glsl
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC.
+// Copyright 2017 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditor/XiWindow.swift
+++ b/XiEditor/XiWindow.swift
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditorTests/XiEditorTests.swift
+++ b/XiEditorTests/XiEditorTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/XiEditorUITests/XiEditorUITests.swift
+++ b/XiEditorUITests/XiEditorUITests.swift
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All rights reserved.
+// Copyright 2016 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Following guidance from https://opensource.google.com/docs/releasing/authors/
this patch changes the copyright message to "The xi-editor Authors" and
creates an AUTHORS file for contributors to record their name.

Also minor update to the contribution guidelines to remind people to add their
name to AUTHORS, and tweak the rules for approving and merging patches.