### PR TITLE
Keep I-beam cursor when modifier key is released

### DIFF
--- a/XiEditor/EditViewController.swift
+++ b/XiEditor/EditViewController.swift
@@ -465,9 +465,9 @@ class EditViewController: NSViewController, EditViewDataSource, FindDelegate, Sc
     //MARK: Other system events
     override func flagsChanged(with event: NSEvent) {
         if event.modifierFlags.contains(.option) {
-            NSCursor.crosshair.set()
+            scrollView.contentView.documentCursor = NSCursor.crosshair
         } else {
-            NSCursor.arrow.set()
+            scrollView.contentView.documentCursor = NSCursor.iBeam
         }
     }
 


### PR DESCRIPTION
Currently, if you hover over the `editView` and press/release a modifier key, the cursor changes from an I-beam to an arrow. This PR makes it keep the I-beam appearance. (It also restricts cursor changes to the active window, since that seems to be the standard behavior elsewhere.)