### PR TITLE
Fix dismiss find causing overscroll

### DIFF
--- a/XiEditor/Search.swift
+++ b/XiEditor/Search.swift
@@ -205,7 +205,7 @@ extension EditViewController {
             
             let offset = findViewController.view.fittingSize.height
             let origin = scrollView.contentView.visibleRect.origin
-            scrollView.contentView.scroll(to: NSMakePoint(origin.x ,origin.y + offset))
+            scrollView.contentView.scroll(to: NSMakePoint(origin.x, origin.y - offset))
         }
 
         editView.window?.makeFirstResponder(editView)


### PR DESCRIPTION
Currently on master, if the find view is opened and quickly dismissed without typing anything, the view is scrolled beyond the window. This commit fixes that issue.

