### PR TITLE
Fix flashing title bar color

### DIFF
--- a/XiEditor/AppDelegate.swift
+++ b/XiEditor/AppDelegate.swift
@@ -369,7 +369,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, XiClient {
         }
     }
 
+    // Stores the config dict so new windows don't have to wait for core to send it.
+    // The main purpose of this is ensuring that `unified_titlebar` applies immediately.
+    var configCache: [String: AnyObject] = [:]
+
     func configChanged(viewIdentifier: ViewIdentifier, changes: [String : AnyObject]) {
+        for (key, value) in changes {
+            self.configCache[key] = value
+        }
         let document = documentForViewIdentifier(viewIdentifier: viewIdentifier)
         DispatchQueue.main.async {
             document?.editViewController?.configChanged(changes: changes)

--- a/XiEditor/Document.swift
+++ b/XiEditor/Document.swift
@@ -77,6 +77,9 @@ class Document: NSDocument {
         windowController.window?.minSize = Document.minWinSize
 
         self.editViewController = windowController.contentViewController as? EditViewController
+        if let config = (NSApplication.shared.delegate as? AppDelegate)?.configCache {
+            editViewController?.configChanged(changes: config)
+        }
         editViewController?.document = self
         windowController.window?.delegate = editViewController
         self.addWindowController(windowController)


### PR DESCRIPTION
When a new tab is created, it has a light gray title bar for a few dozen milliseconds, even if the theme is dark and `unified_titlebar = true`. This is because the config dictionary is sent to new tabs asynchronously after they're created; once this happens the title bar takes on the correct theme color.

Having not read through the entire config system, I think it makes sense for `AppDelegate` to cache the dictionary and send it to new windows/tabs immediately before they appear.